### PR TITLE
fix hasCommit does not be reset when user presee any key.

### DIFF
--- a/src/IBusChewingEngine-input-events.c
+++ b/src/IBusChewingEngine-input-events.c
@@ -229,7 +229,7 @@ void ibus_chewing_engine_handle_Default(IBusChewingEngine *self, guint keyval, g
     G_DEBUG_MSG(2,"[I2] handle_Default(-,%u) plainZhuyin=%s inputMode=%d",
 	    keyval,(self->chewingFlags & CHEWING_FLAG_PLAIN_ZHUYIN)? "TRUE": "FALSE",self->inputMode);
     ibus_chewing_engine_set_status_flag(self, ENGINE_STATUS_NEED_COMMIT);
-    self->hasCommit=1;
+    self->hasCommit=0;
 #ifdef EASY_SYMBOL_INPUT_WORK_AROUND
     if (self->chewingFlags & CHEWING_FLAG_EASY_SYMBOL_INPUT){
 	/* If shift is pressed, turn on the  easySymbolInput, turn off


### PR DESCRIPTION
I sent a patch for fixing duplicate commit string many month ago, and I just found there was a typo in my patch

the hasCommit flag should be reset to 0 when user press anykey after they commit string.

sorry for my mistake.

please review it if you have time, thanks.
