### PR TITLE
ibus-chewing deletes characters if too many of them are entered

### DIFF
--- a/src/IBusChewingEngine-input-events.c
+++ b/src/IBusChewingEngine-input-events.c
@@ -84,6 +84,7 @@ gboolean ibus_chewing_engine_process_key_event(IBusEngine *engine,
 			 * Fix for space in Temporary English mode.
 			 */
 			chewing_handle_Space(self->context);
+			ibus_chewing_engine_set_status_flag(self,ENGINE_STATUS_NEED_COMMIT);
 		    }
 		    if (self->inputMode==CHEWING_INPUT_MODE_SELECTION_DONE ||
 			    self->inputMode==CHEWING_INPUT_MODE_BYPASS )


### PR DESCRIPTION
https://bugs.launchpad.net/ubuntu/+source/ibus-chewing/+bug/1014456
