### PR TITLE
Fix github issue #25

### DIFF
--- a/src/IBusChewingEngine.gob
+++ b/src/IBusChewingEngine.gob
@@ -473,16 +473,8 @@ class IBus:Chewing:Engine from IBus:Engine{
 
 	gint cursorRight=0;
 	gint charLen=(gint) g_utf8_strlen(iText->text, -1);
-	switch(self->inputMode){
-	    case CHEWING_INPUT_MODE_SELECTING:
-		cursorRight=*chiSymbolCursor + MAX(zhuyin_item_written, 1);
-		break;
-	    case CHEWING_INPUT_MODE_EDITING:
-	    case CHEWING_INPUT_MODE_SELECTION_DONE:
-	    default: /* BYPASS */
-		cursorRight=*chiSymbolCursor + MAX(zhuyin_item_written, 1);
-		break;
-	}
+
+	cursorRight=*chiSymbolCursor + zhuyin_item_written;
 
 	G_DEBUG_MSG(5,"[I5]  decorate_preedit() charLen=%d cursorRight=%d", charLen, cursorRight);
 	if (*chiSymbolCursor< cursorRight){


### PR DESCRIPTION
Prevent decorate unavailable data

All cases in the switch do the same thing, and I think the max( , 1) logic is guaranteed by
later (*chiSymbolCursor < cursorRight) check.
