### PR TITLE
補上 #33 第一個空白無法輸入

### DIFF
--- a/src/IBusChewingEngine-input-events.c
+++ b/src/IBusChewingEngine-input-events.c
@@ -97,6 +97,7 @@ gboolean ibus_chewing_engine_process_key_event(IBusEngine *engine,
 			/**
 			 * Fix for space in Temporary English mode.
 			 */
+            chewing_set_easySymbolInput(self->context, 0); /* fixed #33 first space wouldn't be committed */
 			chewing_handle_Space(self->context);
 			ibus_chewing_engine_set_status_flag(self,ENGINE_STATUS_NEED_COMMIT);
 		    }


### PR DESCRIPTION
這個 bug 是 #33 中談到的，「剛切換至新酷音時，第一個空白無法送出」
輸入別的文字之後，又能將空白輸入進去了

我發現好像在其他能夠輸入空白的狀況，EasySymbolInput 的狀態都是 0
但是剛從其他輸入法切換至新酷音時 EasySymbolInput 會是 1
因此補上這麼一行

目前測試過幾個狀況的空白似乎都沒有因此被破壞
（因為找不到 test 可以測試，只好想一下可能會破壞哪些東西）
1. 中文輸入到一半，按 shit 切到英文模式，空白依然能正常輸入
2. 啟動空白選字時，依然沒有被破壞
