### PR TITLE
Update input-events

### DIFF
--- a/src/IBusChewingEngine-input-events.c
+++ b/src/IBusChewingEngine-input-events.c
@@ -34,13 +34,7 @@ gboolean ibus_chewing_engine_process_key_event(IBusEngine *engine,
 
     if (modifiers & IBUS_RELEASE_MASK){
 	if (!keysym_KP_to_normal(kSym) && (kSym==IBUS_Shift_L || kSym==IBUS_Shift_R) && self->_priv->key_last==kSym){
-	    /* When Chi->Eng with incomplete character */
-	    if (chewing_get_ChiEngMode(self->context) && !chewing_zuin_Check(self->context)){
-	        /* chewing_zuin_Check==0 means incomplete character */
-	        /* Send a space to finish the character */
-	        chewing_handle_Space(self->context);
-	     }
-             chewing_set_ChiEngMode(self->context, ! chewing_get_ChiEngMode(self->context));
+             chewing_set_ChiEngMode(self->context, !chewing_get_ChiEngMode(self->context));
 	     self_refresh_property(self,"chewing_chieng_prop");
 	     return self_update(self);
 	}
@@ -159,12 +153,6 @@ gboolean ibus_chewing_engine_process_key_event(IBusEngine *engine,
 		    chewing_handle_Tab(self->context);
 		    break;
 		case IBUS_Caps_Lock:
-		    /* When Chi->Eng with incomplete character */
-		    if (chewing_get_ChiEngMode(self->context) && !chewing_zuin_Check(self->context)){
-			/* chewing_zuin_Check==0 means incomplete character */
-			/* Send a space to finish the character */
-			chewing_handle_Space(self->context);
-		    }
 		    chewing_handle_Capslock(self->context);
 		    self_refresh_property(self,"chewing_chieng_prop");
 		    break;
@@ -219,7 +207,6 @@ gboolean ibus_chewing_engine_process_key_event(IBusEngine *engine,
 	    case IBUS_space:
 	    case IBUS_KP_Space:
 		chewing_handle_ShiftSpace(self->context);
-		chewing_set_ShapeMode(self->context, !chewing_get_ShapeMode(self->context));
 		self_refresh_property(self,"chewing_alnumSize_prop");
 		break;
 	    default:


### PR DESCRIPTION
Remove the following workarounds since libchewing 0.4.0
can do that now:
1. clean up incomplete character in buffer as switching
   ChiEng mode.
2. toggle shape mode with shift-space.
