### PR TITLE
Change to use GLib "g_ascii_toupper" instead of "toupper"

### DIFF
--- a/src/MakerDialogUtil.c
+++ b/src/MakerDialogUtil.c
@@ -249,7 +249,7 @@ gchar *mkdg_str_dash_to_camel(const gchar * argStr)
     int i;
     for (i = 0; i < strlen(argStr); i++) {
 	if (upper) {
-	    g_string_append_c(string, toupper(argStr[i]));
+	    g_string_append_c(string, g_ascii_toupper(argStr[i]));
 	    upper = FALSE;
 	} else {
 	    switch (argStr[i]) {


### PR DESCRIPTION
It is troublesome to use "toupper" with "signed" char.
"g_ascii_toupper" is sufficient and easy for this case.