### PR TITLE
Fix ibus_chewing_pre_edit_clear_pre_edit

### DIFF
--- a/src/IBusChewingPreEdit.c
+++ b/src/IBusChewingPreEdit.c
@@ -175,18 +175,24 @@ void ibus_chewing_pre_edit_clear(IBusChewingPreEdit * self)
 void ibus_chewing_pre_edit_clear_pre_edit(IBusChewingPreEdit * self)
 {
     IBUS_CHEWING_LOG(DEBUG, "ibus_chewing_pre_edit_clear_pre_edit(-)");
-    /* Clear chewing buffer */
+
     /* Save the orig Esc clean buffer state */
     gint origState = chewing_get_escCleanAllBuf(self->context);
-
-    /* Send a false event, then clean it to wipe the commit  */
-    chewing_handle_Default(self->context, '1');
-
     chewing_set_escCleanAllBuf(self->context, TRUE);
-    chewing_handle_Esc(self->context);
-    chewing_set_escCleanAllBuf(self->context, origState);
 
-    ibus_chewing_pre_edit_clear_flag(self, FLAG_UPDATED_OUTGOING);
+    /**
+     * Use ESC to clear chewing buffer. If buffer contains bopomofo
+     * (incomplete character), we have to call ESC twice: one for
+     * bopomofo, one for the rest (complete characcter).
+     */
+    if (bpmf_check) {
+        chewing_handle_Esc(self->context);
+    }
+
+    chewing_handle_Esc(self->context);
+
+    chewing_set_escCleanAllBuf(self->context, origState);
+    ibus_chewing_pre_edit_update(self);
 }
 
 void ibus_chewing_pre_edit_clear_outgoing(IBusChewingPreEdit * self)

--- a/test/IBusChewingPreEdit-test.c
+++ b/test/IBusChewingPreEdit-test.c
@@ -730,6 +730,7 @@ gint main(gint argc, gchar ** argv)
     TEST_RUN_THIS(plain_zhuyin_test);
     TEST_RUN_THIS(plain_zhuyin_shift_symbol_test);
     TEST_RUN_THIS(plain_zhuyin_full_half_shape_test);
+    TEST_RUN_THIS(test_ibus_chewing_pre_edit_clear_pre_edit);
     TEST_RUN_THIS(free_test);
     return g_test_run();
 }

--- a/test/IBusChewingPreEdit-test.c
+++ b/test/IBusChewingPreEdit-test.c
@@ -685,6 +685,17 @@ void plain_zhuyin_full_half_shape_test()
     assert_outgoing_pre_edit("", "");
 }
 
+void test_ibus_chewing_pre_edit_clear_pre_edit()
+{
+    TEST_CASE_INIT();
+
+    key_press_from_string("su3cl"); /* 你ㄏㄠ (尚未完成組字)*/
+    assert_outgoing_pre_edit("", "你ㄏㄠ");
+
+    ibus_chewing_pre_edit_clear_pre_edit(self);
+    assert_outgoing_pre_edit("", "");
+}
+
 gint main(gint argc, gchar ** argv)
 {
     g_test_init(&argc, &argv, NULL);


### PR DESCRIPTION
 * src/IBusChewingPreEdit.c:
    if pre-edit buffer contains bopomofo, we have to call ESC
    twice; one for bopomofo, one for the rest characters.

 * test/IBusChewingPreEdit-test.c:
    add test case for ibus_chewing_pre_edit_clear_pre_edit.
