### PR TITLE
Fix #50: Cannot use Up, Left, PgUp, Ese etc. within "`" menu

### DIFF
--- a/src/IBusChewingPreEdit.c
+++ b/src/IBusChewingPreEdit.c
@@ -479,7 +479,11 @@ EventResponse self_handle_backspace(IBusChewingPreEdit * self, KSym kSym,
 {
     filter_modifiers(0);
     absorb_when_release;
-    ignore_when_buffer_is_empty;
+
+    if (buffer_is_empty && !table_is_showing) {
+        return EVENT_RESPONSE_IGNORE;
+    }
+
     handle_log("backspace");
 
     return
@@ -502,7 +506,11 @@ EventResponse self_handle_escape(IBusChewingPreEdit * self, KSym kSym,
 {
     filter_modifiers(0);
     absorb_when_release;
-    ignore_when_buffer_is_empty;
+
+    if (buffer_is_empty && !table_is_showing) {
+        return EVENT_RESPONSE_IGNORE;
+    }
+
     handle_log("escape");
 
     return event_process_or_ignore(!chewing_handle_Esc(self->context));
@@ -513,7 +521,11 @@ EventResponse self_handle_left(IBusChewingPreEdit * self, KSym kSym,
 {
     filter_modifiers(IBUS_SHIFT_MASK);
     absorb_when_release;
-    ignore_when_buffer_is_empty;
+
+    if (buffer_is_empty && !table_is_showing) {
+        return EVENT_RESPONSE_IGNORE;
+    }
+
     handle_log("left");
 
     if (is_shift_only) {
@@ -530,7 +542,11 @@ EventResponse self_handle_up(IBusChewingPreEdit * self, KSym kSym,
 {
     filter_modifiers(0);
     absorb_when_release;
-    ignore_when_buffer_is_empty;
+
+    if (buffer_is_empty && !table_is_showing) {
+        return EVENT_RESPONSE_IGNORE;
+    }
+
     handle_log("up");
 
     return event_process_or_ignore(!chewing_handle_Up(self->context));
@@ -541,7 +557,11 @@ EventResponse self_handle_right(IBusChewingPreEdit * self, KSym kSym,
 {
     filter_modifiers(IBUS_SHIFT_MASK);
     absorb_when_release;
-    ignore_when_buffer_is_empty;
+
+    if (buffer_is_empty && !table_is_showing) {
+        return EVENT_RESPONSE_IGNORE;
+    }
+
     handle_log("right");
 
     if (is_shift_only) {
@@ -558,7 +578,11 @@ EventResponse self_handle_down(IBusChewingPreEdit * self, KSym kSym,
 {
     filter_modifiers(0);
     absorb_when_release;
-    ignore_when_buffer_is_empty;
+
+    if (buffer_is_empty && !table_is_showing) {
+        return EVENT_RESPONSE_IGNORE;
+    }
+
     handle_log("down");
 
     return event_process_or_ignore(!chewing_handle_Down(self->context));
@@ -569,7 +593,11 @@ EventResponse self_handle_page_up(IBusChewingPreEdit * self, KSym kSym,
 {
     filter_modifiers(0);
     absorb_when_release;
-    ignore_when_buffer_is_empty;
+
+    if (buffer_is_empty && !table_is_showing) {
+        return EVENT_RESPONSE_IGNORE;
+    }
+
     handle_log("page_up");
 
     return event_process_or_ignore(!chewing_handle_PageUp(self->context));
@@ -580,7 +608,11 @@ EventResponse self_handle_page_down(IBusChewingPreEdit * self, KSym kSym,
 {
     filter_modifiers(0);
     absorb_when_release;
-    ignore_when_buffer_is_empty;
+
+    if (buffer_is_empty && !table_is_showing) {
+        return EVENT_RESPONSE_IGNORE;
+    }
+
     handle_log("page_down");
 
     return

--- a/test/IBusChewingPreEdit-test.c
+++ b/test/IBusChewingPreEdit-test.c
@@ -713,6 +713,37 @@ void test_space_as_selection()
     assert_outgoing_pre_edit(" ", "");
 }
 
+void test_arrow_keys_buffer_empty()
+{
+/* Fix #50: Cannot use Up, Down, PgUp, Ese ... etc. within "`" menu */
+
+    TEST_CASE_INIT();
+
+    key_press_from_string("`");
+    g_assert(ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
+    g_assert(chewing_cand_CurrentPage(self->context) == 0);
+    key_press_from_key_sym(IBUS_KEY_Right, 0);
+    g_assert(chewing_cand_CurrentPage(self->context) == 1);
+    key_press_from_key_sym(IBUS_KEY_Left, 0);
+    g_assert(chewing_cand_CurrentPage(self->context) == 0);
+    key_press_from_key_sym(IBUS_KEY_Page_Down, 0);
+    g_assert(chewing_cand_CurrentPage(self->context) == 1);
+    key_press_from_key_sym(IBUS_KEY_Page_Up, 0);
+    g_assert(chewing_cand_CurrentPage(self->context) == 0);
+    key_press_from_key_sym(IBUS_KEY_Up, 0);
+    g_assert(!ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
+
+    key_press_from_string("`");
+    g_assert(ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
+    key_press_from_key_sym(IBUS_KEY_BackSpace, 0);
+    g_assert(!ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
+
+    key_press_from_string("`");
+    g_assert(ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
+    key_press_from_key_sym(IBUS_KEY_Escape, 0);
+    g_assert(!ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
+}
+
 gint main(gint argc, gchar ** argv)
 {
     g_test_init(&argc, &argv, NULL);
@@ -749,6 +780,7 @@ gint main(gint argc, gchar ** argv)
     TEST_RUN_THIS(plain_zhuyin_full_half_shape_test);
     TEST_RUN_THIS(test_ibus_chewing_pre_edit_clear_pre_edit);
     TEST_RUN_THIS(test_space_as_selection);
+    TEST_RUN_THIS(test_arrow_keys_buffer_empty);
     TEST_RUN_THIS(free_test);
     return g_test_run();
 }


### PR DESCRIPTION
 * src/IBusChewingPreEdit.c
   Althogh the pre-edit-buffer is empty, but users still need
   up, down, left, right, page-up, page-down, backspace, and
   escape key to close or turn pages of candidate list.

 * test/IBusChewingPreEdit-test.c
   add test case