### PR TITLE
Add ibus_chewing_pre_edit_clear_bopomofo()

### DIFF
--- a/src/IBusChewingPreEdit.c
+++ b/src/IBusChewingPreEdit.c
@@ -172,22 +172,33 @@ void ibus_chewing_pre_edit_clear(IBusChewingPreEdit * self)
     ibus_chewing_pre_edit_update(self);
 }
 
+void ibus_chewing_pre_edit_clear_bopomofo(IBusChewingPreEdit * self)
+{
+    IBUS_CHEWING_LOG(DEBUG, "ibus_chewing_pre_edit_clear_bopomofo(-)");
+
+    /* Esc key can close candidate list, clear bopomofo, and clear 
+     * the whole pre-edit buffer. Make sure it acts as we expected.
+     */
+    if (table_is_showing) {
+        chewing_handle_Esc(self->context);
+    }
+
+    if (bpmf_check) {
+        chewing_handle_Esc(self->context);
+    }
+
+    ibus_chewing_pre_edit_update(self);
+}
+
 void ibus_chewing_pre_edit_clear_pre_edit(IBusChewingPreEdit * self)
 {
     IBUS_CHEWING_LOG(DEBUG, "ibus_chewing_pre_edit_clear_pre_edit(-)");
 
+    ibus_chewing_pre_edit_clear_bopomofo(self);
+
     /* Save the orig Esc clean buffer state */
     gint origState = chewing_get_escCleanAllBuf(self->context);
     chewing_set_escCleanAllBuf(self->context, TRUE);
-
-    /**
-     * Use ESC to clear chewing buffer. If buffer contains bopomofo
-     * (incomplete character), we have to call ESC twice: one for
-     * bopomofo, one for the rest (complete characcter).
-     */
-    if (bpmf_check) {
-        chewing_handle_Esc(self->context);
-    }
 
     chewing_handle_Esc(self->context);
 

--- a/src/IBusChewingPreEdit.c
+++ b/src/IBusChewingPreEdit.c
@@ -229,9 +229,9 @@ gboolean ibus_chewing_pre_edit_get_full_half_mode(IBusChewingPreEdit *
 void ibus_chewing_pre_edit_set_chi_eng_mode(IBusChewingPreEdit * self,
 					    gboolean chineseMode)
 {
-    /* When Chi->Eng with incomplete character */
+    /* Clear bopomofo when toggling Chi-Eng Mode */
     if (!chineseMode && is_chinese && bpmf_check) {
-	ibus_chewing_pre_edit_force_commit(self);
+        ibus_chewing_pre_edit_clear_bopomofo(self);
     }
     chewing_set_ChiEngMode(self->context, (chineseMode) ? 1 : 0);
 }
@@ -240,8 +240,8 @@ void ibus_chewing_pre_edit_set_full_half_mode(IBusChewingPreEdit * self,
 					      gboolean fullShapeMode)
 {
     if (is_chinese && bpmf_check) {
-	/* When Chi->Eng with incomplete character */
-	ibus_chewing_pre_edit_force_commit(self);
+    /* Clear bopomofo when toggling Full-Half Mode */
+        ibus_chewing_pre_edit_clear_bopomofo(self);
     }
     chewing_set_ShapeMode(self->context, (fullShapeMode) ? 1 : 0);
 }
@@ -389,20 +389,19 @@ EventResponse self_handle_caps_lock(IBusChewingPreEdit * self, KSym kSym,
 				    KeyModifiers unmaskedMod)
 {
     filter_modifiers(0);
+
     if (!ibus_chewing_pre_edit_get_property_boolean(self,
-						    "capslock-toggle-chinese"))
-    {
-	/* Ignore the Caps Lock event when Caps Lock does not toggle Chinese */
-	return EVENT_RESPONSE_IGNORE;
+						    "capslock-toggle-chinese")) {
+        /* Ignore the Caps Lock event when it does not toggle Chinese */
+        return EVENT_RESPONSE_IGNORE;
     }
 
     absorb_when_release;
     handle_log("caps_lock");
 
-
-    /* When Chi->Eng with incomplete character */
+    /* Clear bopomofo when toggling Chi-Eng Mode */
     if (is_chinese && bpmf_check) {
-	ibus_chewing_pre_edit_force_commit(self);
+        ibus_chewing_pre_edit_clear_bopomofo(self);
     }
 
     return

--- a/src/IBusChewingPreEdit.h
+++ b/src/IBusChewingPreEdit.h
@@ -164,6 +164,7 @@ gchar *ibus_chewing_pre_edit_get_outgoing(IBusChewingPreEdit * self);
 
 void ibus_chewing_pre_edit_force_commit(IBusChewingPreEdit * self);
 void ibus_chewing_pre_edit_clear(IBusChewingPreEdit * self);
+void ibus_chewing_pre_edit_clear_bopomofo(IBusChewingPreEdit * self);
 void ibus_chewing_pre_edit_clear_pre_edit(IBusChewingPreEdit * self);
 void ibus_chewing_pre_edit_clear_outgoing(IBusChewingPreEdit * self);
 

--- a/test/IBusChewingPreEdit-test.c
+++ b/test/IBusChewingPreEdit-test.c
@@ -690,7 +690,6 @@ void plain_zhuyin_full_half_shape_test()
     assert_outgoing_pre_edit("", "");
 }
 
-
 void test_ibus_chewing_pre_edit_clear_bopomofo()
 {
     TEST_CASE_INIT();
@@ -711,6 +710,16 @@ void test_ibus_chewing_pre_edit_clear_pre_edit()
 
     ibus_chewing_pre_edit_clear_pre_edit(self);
     assert_outgoing_pre_edit("", "");
+}
+
+void test_ibus_chewing_pre_edit_set_chi_eng_mode()
+{
+    TEST_CASE_INIT();    
+
+    key_press_from_string("su3cl"); /* 你ㄏㄠ (尚未完成組字)*/
+    ibus_chewing_pre_edit_set_chi_eng_mode(self, FALSE);
+    g_assert(chewing_get_ChiEngMode(self->context) == 0);
+    assert_outgoing_pre_edit("", "你");
 }
 
 void test_space_as_selection()
@@ -792,6 +801,7 @@ gint main(gint argc, gchar ** argv)
     TEST_RUN_THIS(plain_zhuyin_full_half_shape_test);
     TEST_RUN_THIS(test_ibus_chewing_pre_edit_clear_bopomofo);
     TEST_RUN_THIS(test_ibus_chewing_pre_edit_clear_pre_edit);
+    TEST_RUN_THIS(test_ibus_chewing_pre_edit_set_chi_eng_mode);
     TEST_RUN_THIS(test_space_as_selection);
     TEST_RUN_THIS(test_arrow_keys_buffer_empty);
     TEST_RUN_THIS(free_test);

--- a/test/IBusChewingPreEdit-test.c
+++ b/test/IBusChewingPreEdit-test.c
@@ -690,6 +690,18 @@ void plain_zhuyin_full_half_shape_test()
     assert_outgoing_pre_edit("", "");
 }
 
+
+void test_ibus_chewing_pre_edit_clear_bopomofo()
+{
+    TEST_CASE_INIT();
+
+    key_press_from_string("su3cl"); /* 你ㄏㄠ (尚未完成組字)*/
+    assert_outgoing_pre_edit("", "你ㄏㄠ");
+
+    ibus_chewing_pre_edit_clear_bopomofo(self);
+    assert_outgoing_pre_edit("", "你");
+}
+
 void test_ibus_chewing_pre_edit_clear_pre_edit()
 {
     TEST_CASE_INIT();
@@ -701,9 +713,9 @@ void test_ibus_chewing_pre_edit_clear_pre_edit()
     assert_outgoing_pre_edit("", "");
 }
 
-/* GitHub #79: Cannot input space when "space to select" is enabled  */
 void test_space_as_selection()
 {
+/* GitHub #79: Cannot input space when "space to select" is enabled  */
     TEST_CASE_INIT();
     ibus_chewing_pre_edit_set_apply_property_boolean(self,
 						     "space-as-selection",
@@ -715,7 +727,7 @@ void test_space_as_selection()
 
 void test_arrow_keys_buffer_empty()
 {
-/* Fix #50: Cannot use Up, Down, PgUp, Ese ... etc. within "`" menu */
+/* GitHub #50: Cannot use Up, Down, PgUp, Ese ... etc. within "`" menu */
 
     TEST_CASE_INIT();
 
@@ -778,6 +790,7 @@ gint main(gint argc, gchar ** argv)
     TEST_RUN_THIS(plain_zhuyin_test);
     TEST_RUN_THIS(plain_zhuyin_shift_symbol_test);
     TEST_RUN_THIS(plain_zhuyin_full_half_shape_test);
+    TEST_RUN_THIS(test_ibus_chewing_pre_edit_clear_bopomofo);
     TEST_RUN_THIS(test_ibus_chewing_pre_edit_clear_pre_edit);
     TEST_RUN_THIS(test_space_as_selection);
     TEST_RUN_THIS(test_arrow_keys_buffer_empty);


### PR DESCRIPTION
1. 和 libchewing 保持一致，切換英數模式時只清除預編區的注音符號，而非 force commit。
2. 為了只清除預編區的注音符號，新增 ``ibus_chewing_pre_edit_clear_bopomofo()``
3. 切換全形半形模式時應該可以不必更動預編區，但未免有其他預期外的問題，還是設定為清空注音符號