### PR TITLE
Fix #63: Cannnot add user-phrase via ctrl+num

### DIFF
--- a/src/IBusChewingPreEdit.c
+++ b/src/IBusChewingPreEdit.c
@@ -771,8 +771,6 @@ gboolean ibus_chewing_pre_edit_process_key
 		     unmaskedMod, modifiers_to_string(unmaskedMod));
     process_key_debug("Before response");
 
-    gboolean bufferEmpty =
-	(ibus_chewing_pre_edit_length(self) == 0) ? TRUE : FALSE;
     /* Find corresponding rule */
     EventResponse response;
     response = handle_key(kSym, unmaskedMod);
@@ -786,13 +784,6 @@ gboolean ibus_chewing_pre_edit_process_key
     case EVENT_RESPONSE_ABSORB:
 	return TRUE;
     case EVENT_RESPONSE_IGNORE:
-	/* Play conservatively, commit everything when unhandled key is received.
-	 * Use case: In gedit, press Ctrl-F to open search UI 
-	 * Better to commit every thing before the search field active.
-	 */
-	if (!bufferEmpty) {
-	    ibus_chewing_pre_edit_force_commit(self);
-	}
 	return FALSE;
     default:
 	break;

--- a/test/IBusChewingPreEdit-test.c
+++ b/test/IBusChewingPreEdit-test.c
@@ -765,6 +765,16 @@ void test_arrow_keys_buffer_empty()
     g_assert(!ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
 }
 
+void test_ctrol_1_open_candidate_list()
+{
+/* GitHub #63: Cannnot add user-phrase via ctrl+num */
+
+    TEST_CASE_INIT();
+
+    key_press_from_key_sym(IBUS_KEY_1, IBUS_CONTROL_MASK);
+    g_assert(ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
+}
+
 gint main(gint argc, gchar ** argv)
 {
     g_test_init(&argc, &argv, NULL);
@@ -804,6 +814,7 @@ gint main(gint argc, gchar ** argv)
     TEST_RUN_THIS(test_ibus_chewing_pre_edit_set_chi_eng_mode);
     TEST_RUN_THIS(test_space_as_selection);
     TEST_RUN_THIS(test_arrow_keys_buffer_empty);
+    TEST_RUN_THIS(test_ctrol_1_open_candidate_list);
     TEST_RUN_THIS(free_test);
     return g_test_run();
 }


### PR DESCRIPTION
1. Ctrol 鍵會觸發 ``EVENT_RESPONSE_IGNORE`` 和 ``force_commit``，導致無法使用 control + num 新增使用者詞彙，所以先將 force_commit 移除。

2. 用 control + 1 開啟符號清單來檢查 control + num 功能
