### PR TITLE
Modify dropdown menu for selecting keys

### DIFF
--- a/src/IBusChewingProperties.c
+++ b/src/IBusChewingProperties.c
@@ -74,7 +74,7 @@ MkdgPropertySpec propSpecs[] = {
      0,
      0,
      selKeys_apply_callback,
-     MKDG_PROPERTY_FLAG_NO_NEW | MKDG_PROPERTY_FLAG_HAS_TRANSLATION,
+     MKDG_PROPERTY_FLAG_NO_NEW,
      N_
      ("Keys used to select candidate. For example \"asdfghjkl;\", press 'a' to select the 1st candidate, 's' for 2nd, and so on."),
      NULL}

--- a/src/IBusChewingProperties.c
+++ b/src/IBusChewingProperties.c
@@ -73,7 +73,8 @@ MkdgPropertySpec propSpecs[] = {
      IBUS_CHEWING_PROPERTIES_SUBSECTION, "1234567890", selKeys_array, NULL,
      0,
      0,
-     selKeys_apply_callback, 0,
+     selKeys_apply_callback,
+     MKDG_PROPERTY_FLAG_NO_NEW | MKDG_PROPERTY_FLAG_HAS_TRANSLATION,
      N_
      ("Keys used to select candidate. For example \"asdfghjkl;\", press 'a' to select the 1st candidate, 's' for 2nd, and so on."),
      NULL}


### PR DESCRIPTION
如果沒錯的話，使用者不能自己隨意輸入選字鍵，只能從現有組合中挑選一種，但目前設定視窗裡的選擇清單看起來像是可以讓使用者自行輸入（如附圖），實際點選輸入區的話又會自動關閉，所以改成和『鍵盤排列』一樣。


![ibus-chewing-setting](https://cloud.githubusercontent.com/assets/1015601/15867292/2cc604e8-2d15-11e6-8133-caee347735d3.png)