### PR TITLE
Fix #88: Use keypad to select candidates or input numbers directly

### DIFF
--- a/src/IBusChewingApplier.c
+++ b/src/IBusChewingApplier.c
@@ -139,13 +139,6 @@ syncCapsLock_apply_callback(PropertyContext * ctx, gpointer userData)
 }
 
 gboolean
-numpadAlwaysNumber_apply_callback(PropertyContext * ctx, gpointer userData)
-{
-    /* Use MkdgProperty directly, no need to call IBusChewingEngine */
-    return TRUE;
-}
-
-gboolean
 shiftToggleChinese_apply_callback(PropertyContext * ctx, gpointer userData)
 {
     GValue *value = &(ctx->value);

--- a/src/IBusChewingPreEdit.c
+++ b/src/IBusChewingPreEdit.c
@@ -362,27 +362,32 @@ EventResponse self_handle_num_keypad(IBusChewingPreEdit * self,
     absorb_when_release;
     handle_log("num_keypad");
 
+    KSym kSymEquiv = key_sym_KP_to_normal(kSym);
+
     if ((maskedMod != 0) && (!is_shift_only) && (!is_ctrl_only)) {
 	return EVENT_RESPONSE_IGNORE;
     }
 
-
-    KSym kSymFinal = kSym;
-    KSym kSymEquiv = key_sym_KP_to_normal(kSym);
-    gboolean numpadIsAlwaysNum =
-	ibus_chewing_pre_edit_get_property_boolean(self,
-						   "numpad-always-number");
-
-    if (numpadIsAlwaysNum) {
-	kSymFinal = kSymEquiv;
-    }
     if (is_ctrl_only) {
 	return
 	    event_process_or_ignore(!chewing_handle_CtrlNum
-				    (self->context, kSymFinal));
+				    (self->context, kSymEquiv));
     }
+
+    if (bpmf_check) {
+        return EVENT_RESPONSE_IGNORE;
+    }
+
+    if (!buffer_is_empty && table_is_showing) {
+        return EVENT_RESPONSE_IGNORE;
+    }
+
     /* maskedMod= 0 */
-    return self_handle_key_sym_default(self, kSym, unmaskedMod);
+    gint origChiEngMode = chewing_get_ChiEngMode(self->context);
+    ibus_chewing_pre_edit_set_chi_eng_mode(self, FALSE);
+
+    return self_handle_key_sym_default(self, kSymEquiv, unmaskedMod);
+    ibus_chewing_pre_edit_set_chi_eng_mode(self, origChiEngMode);
 }
 
 EventResponse self_handle_caps_lock(IBusChewingPreEdit * self, KSym kSym,

--- a/src/IBusChewingProperties.c
+++ b/src/IBusChewingProperties.c
@@ -150,13 +150,6 @@ MkdgPropertySpec propSpecs[] = {
       "\"keyboard\": IM status follows keyboard status\n"
       "\"IM\": Keyboard status follows IM status"), NULL}
     ,
-    {G_TYPE_BOOLEAN, "numpad-always-number", PAGE_EDITING,
-     N_("Number pad always input number"),
-     IBUS_CHEWING_PROPERTIES_SUBSECTION, "1", NULL, NULL, 0, 1,
-     numpadAlwaysNumber_apply_callback, 0,
-     N_("Always input numbers when number keys from key pad is inputted"),
-     NULL}
-    ,
     {G_TYPE_BOOLEAN, "shift-toggle-chinese", PAGE_EDITING,
      N_("Shift toggle Chinese Mode"),
      IBUS_CHEWING_PROPERTIES_SUBSECTION, "1", NULL, NULL, 0, 1,

--- a/test/IBusChewingPreEdit-test.c
+++ b/test/IBusChewingPreEdit-test.c
@@ -765,7 +765,7 @@ void test_arrow_keys_buffer_empty()
     g_assert(!ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
 }
 
-void test_ctrol_1_open_candidate_list()
+void test_ctrl_1_open_candidate_list()
 {
 /* GitHub #63: Cannnot add user-phrase via ctrl+num */
 
@@ -773,6 +773,70 @@ void test_ctrol_1_open_candidate_list()
 
     key_press_from_key_sym(IBUS_KEY_1, IBUS_CONTROL_MASK);
     g_assert(ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
+}
+
+void test_kp_eng_mode()
+{
+/* Eng-Mode: keypad outputs numbers directly */
+
+    TEST_CASE_INIT();
+
+    ibus_chewing_pre_edit_set_chi_eng_mode(self, FALSE);
+    g_assert(chewing_get_ChiEngMode(self->context) == 0);
+
+    key_press_from_key_sym(IBUS_KP_1, 0);
+    key_press_from_key_sym(IBUS_KEY_KP_9, 0);
+    key_press_from_key_sym(IBUS_KP_0, 0);
+    assert_outgoing_pre_edit("190", "");
+}
+
+void test_kp_chi_default()
+{
+/* Chi-Mode: keypad outputs numbers by default */
+
+    TEST_CASE_INIT();
+
+    g_assert(chewing_get_ChiEngMode(self->context) == 1);
+
+    key_press_from_key_sym(IBUS_KP_1, 0);
+    key_press_from_key_sym(IBUS_KEY_KP_9, 0);
+    key_press_from_key_sym(IBUS_KP_0, 0);
+    assert_outgoing_pre_edit("190", "");
+}
+
+void test_kp_chi_incomplete()
+{
+/* Chi-Mode with incomplete character: do nothing */
+
+    TEST_CASE_INIT();
+
+    g_assert(chewing_get_ChiEngMode(self->context) == 1);
+
+    key_press_from_string("su3cl"); /* 你ㄏㄠ (尚未完成組字) */
+    key_press_from_key_sym(IBUS_KP_1, 0);
+    assert_outgoing_pre_edit("", "你ㄏㄠ");
+}
+
+void test_kp_selecting()
+{
+/* While selecting candidates: select or do nothing */
+
+    TEST_CASE_INIT();
+
+    key_press_from_key_sym(IBUS_KP_1, IBUS_CONTROL_MASK);
+    g_assert(ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
+    key_press_from_key_sym(IBUS_KP_2, 0);
+    assert_outgoing_pre_edit("", "※");
+
+//  TODO: need to check if selkeys are 1234567890
+}
+
+void test_keypad()
+{
+    test_kp_eng_mode();
+    test_kp_chi_default();
+    test_kp_chi_incomplete();
+    test_kp_selecting();
 }
 
 gint main(gint argc, gchar ** argv)
@@ -814,7 +878,8 @@ gint main(gint argc, gchar ** argv)
     TEST_RUN_THIS(test_ibus_chewing_pre_edit_set_chi_eng_mode);
     TEST_RUN_THIS(test_space_as_selection);
     TEST_RUN_THIS(test_arrow_keys_buffer_empty);
-    TEST_RUN_THIS(test_ctrol_1_open_candidate_list);
+    TEST_RUN_THIS(test_ctrl_1_open_candidate_list);
+    TEST_RUN_THIS(test_keypad);
     TEST_RUN_THIS(free_test);
     return g_test_run();
 }


### PR DESCRIPTION
 * src/IBusChewingPreEdit.c
   Eng-Mode: output numbers
   Chi-Mode-default: output numbers
   Chi-Mode-incomplete: no response
   Selecting(selkeys are 1~0): select
   Selecting(selkeys are NOT 1~0): no response

 * src/IBusChewingProperties.c
   remove "numpad-always-number"

 * test/IBusChewingPreEdit-test.c
   1. add test case
   2. fix typo