### PR TITLE
Tweak max max-chi-symbol-len

### DIFF
--- a/src/IBusChewingApplier.c
+++ b/src/IBusChewingApplier.c
@@ -106,7 +106,7 @@ maxChiSymbolLen_apply_callback(PropertyContext * ctx, gpointer userData)
     GValue *value = &(ctx->value);
     IBusChewingPreEdit *icPreEdit = (IBusChewingPreEdit *) ctx->parent;
     chewing_set_maxChiSymbolLen(icPreEdit->context,
-				g_value_get_int(value));
+				g_value_get_int(value) + 5); /* 5 for incomplete bopomofos */
     return TRUE;
 }
 

--- a/src/IBusChewingProperties.c
+++ b/src/IBusChewingProperties.c
@@ -130,10 +130,10 @@ MkdgPropertySpec propSpecs[] = {
     ,
     {G_TYPE_INT, "max-chi-symbol-len", PAGE_EDITING,
      N_("Maximum Chinese characters"),
-     IBUS_CHEWING_PROPERTIES_SUBSECTION, "20", NULL, NULL, 8, 39,
+     IBUS_CHEWING_PROPERTIES_SUBSECTION, "20", NULL, NULL, 11, 33,
      maxChiSymbolLen_apply_callback, 0,
      N_
-     ("Maximum Chinese characters in pre-edit buffer, including inputing Zhuyin symbols."),
+     ("Maximum Chinese characters in pre-edit buffer, not including inputing Zhuyin symbols."),
      NULL}
     ,
     /* Sync between CapsLock and IM */


### PR DESCRIPTION
（1）使用者在設定預編區字數時多半不會想到輸入中的注音符號，就算想到也不知道該預留多少空位。

舉例來說，如果使用者想要預編區有 8 個字並且保持在可以選字的狀態，目前必須要自己加上 5。如果只 +4，輸入完第 8 字就會因為預編區額滿而送出字。

所以讓 ibus-chewing 幫使用者 +5，使用者就可以得到預期的結果。

（2）libchewing 內建詞庫的最長詞彙是 11 個字，所以預編區應該最少要容納 11 個字（不含輸入中的注音符號）。