### PR TITLE
Fix keypad

### DIFF
--- a/src/IBusChewingPreEdit.c
+++ b/src/IBusChewingPreEdit.c
@@ -374,20 +374,17 @@ EventResponse self_handle_num_keypad(IBusChewingPreEdit * self,
 				    (self->context, kSymEquiv));
     }
 
-    if (bpmf_check) {
-        return EVENT_RESPONSE_IGNORE;
-    }
-
-    if (!buffer_is_empty && table_is_showing) {
-        return EVENT_RESPONSE_IGNORE;
-    }
-
-    /* maskedMod= 0 */
+    /* maskedMod = 0 */
+    /* switch to eng-mode temporary */
     gint origChiEngMode = chewing_get_ChiEngMode(self->context);
     ibus_chewing_pre_edit_set_chi_eng_mode(self, FALSE);
 
-    return self_handle_key_sym_default(self, kSymEquiv, unmaskedMod);
-    ibus_chewing_pre_edit_set_chi_eng_mode(self, origChiEngMode);
+    EventResponse 
+    response = self_handle_key_sym_default(self, kSymEquiv, unmaskedMod);
+
+    chewing_set_ChiEngMode(self->context, origChiEngMode);
+
+    return response;
 }
 
 EventResponse self_handle_caps_lock(IBusChewingPreEdit * self, KSym kSym,
@@ -759,6 +756,8 @@ KeyHandlingRule keyHandlingRules[] = {
        IBUS_KEY_End, IBUS_KEY_End, self_handle_end}
     , {
        IBUS_KEY_KP_End, IBUS_KEY_KP_End, self_handle_end}
+    , {
+       IBUS_KP_Multiply, IBUS_KP_Divide, self_handle_num_keypad}
     , {
        128, G_MAXUINT, self_handle_special}
     , {

--- a/src/IBusChewingUtil.c
+++ b/src/IBusChewingUtil.c
@@ -65,20 +65,22 @@ void add_tone(char *str, gint tone)
 KSym key_sym_KP_to_normal(KSym k)
 {
     if (k < IBUS_KP_0 || k > IBUS_KP_9) {
-	switch (k) {
-	case IBUS_KP_Decimal:
-	    return IBUS_period;
-	case IBUS_KP_Add:
-	    return IBUS_plus;
-	case IBUS_KP_Subtract:
-	    return IBUS_minus;
-	case IBUS_KP_Multiply:
-	    return IBUS_asterisk;
-	case IBUS_KP_Divide:
-	    return IBUS_slash;
-	default:
-	    return 0;
-	}
+        switch (k) {
+        case IBUS_KP_Multiply:
+            return IBUS_asterisk;
+        case IBUS_KP_Add:
+            return IBUS_plus;
+        case IBUS_KP_Separator:
+            return IBUS_comma;
+        case IBUS_KP_Subtract:
+            return IBUS_minus;
+        case IBUS_KP_Decimal:
+            return IBUS_period;
+        case IBUS_KP_Divide:
+            return IBUS_slash;
+        default:
+            return 0;
+        }
     }
     return k - IBUS_KP_0 + IBUS_0;
 }
@@ -192,6 +194,18 @@ const char *key_sym_get_name(KSym k)
 	return "KP_8";
     case IBUS_KP_9:
 	return "KP_9";
+	case IBUS_KP_Multiply:
+	return "KP_Multiply";
+	case IBUS_KP_Add:
+	return "KP_Add";
+	case IBUS_KP_Separator:
+	return "KP_Separator";
+    case IBUS_KP_Subtract:
+	return "KP_Subtract";
+	case IBUS_KP_Decimal:
+	return "KP_Decimal";
+	case IBUS_KP_Divide:
+	return "KP_Divide";
     default:
 	if (isprint(k)) {
 	    return &asciiConst[(k - ' ') * 2];

--- a/test/IBusChewingPreEdit-test.c
+++ b/test/IBusChewingPreEdit-test.c
@@ -496,10 +496,6 @@ void process_key_down_arrow_test()
     ibus_chewing_pre_edit_set_apply_property_boolean(self,
 						     "plain-zhuyin",
 						     FALSE);
-    ibus_chewing_pre_edit_set_apply_property_boolean(self,
-						     "phrase-choice-from-last",
-						     TRUE);
-
     key_press_from_string("t/6g4");
     key_press_from_key_sym(IBUS_KEY_Down, 0);
     key_press_from_string("1");
@@ -794,7 +790,22 @@ void test_kp_eng_mode()
     assert_outgoing_pre_edit("190", "");
 }
 
-void test_kp_chi_default()
+void test_kp_eng_mode_buffer()
+{
+/* Eng-Mode: When buffer is not empty, keypad outputs numbers into buffer. */
+
+    TEST_CASE_INIT();
+
+    key_press_from_string("su3cl3"); /* 你好 */
+    ibus_chewing_pre_edit_set_chi_eng_mode(self, FALSE);
+    g_assert(chewing_get_ChiEngMode(self->context) == 0);
+    key_press_from_key_sym(IBUS_KP_1, 0);
+    key_press_from_key_sym(IBUS_KEY_KP_9, 0);
+    key_press_from_key_sym(IBUS_KP_0, 0);
+    assert_outgoing_pre_edit("", "你好190");
+}
+
+void test_kp_chi_mode()
 {
 /* Chi-Mode: keypad outputs numbers by default */
 
@@ -806,11 +817,34 @@ void test_kp_chi_default()
     key_press_from_key_sym(IBUS_KEY_KP_9, 0);
     key_press_from_key_sym(IBUS_KP_0, 0);
     assert_outgoing_pre_edit("190", "");
+
+    /* should remain chi-mode */
+    g_assert(chewing_get_ChiEngMode(self->context) == 1);
+}
+
+void test_kp_chi_mode_buffer()
+{
+/* Chi-Mode: When buffer is not empty, keypad outputs numbers into buffer */
+
+    TEST_CASE_INIT();
+
+    g_assert(chewing_get_ChiEngMode(self->context) == 1);
+
+    key_press_from_string("su3cl3"); /* 你好 */
+    key_press_from_key_sym(IBUS_KP_1, 0);
+    key_press_from_key_sym(IBUS_KEY_KP_9, 0);
+    key_press_from_key_sym(IBUS_KP_0, 0);
+    assert_outgoing_pre_edit("", "你好190");
+
+    /* should remain chi-mode */
+    g_assert(chewing_get_ChiEngMode(self->context) == 1);
 }
 
 void test_kp_chi_incomplete()
 {
-/* Chi-Mode with incomplete character: do nothing */
+/* Chi-Mode with bopmofos (incomplete characters):
+ * clear bopomofos and output numbers into buffer.
+ */
 
     TEST_CASE_INIT();
 
@@ -818,7 +852,7 @@ void test_kp_chi_incomplete()
 
     key_press_from_string("su3cl"); /* 你ㄏㄠ (尚未完成組字) */
     key_press_from_key_sym(IBUS_KP_1, 0);
-    assert_outgoing_pre_edit("", "你ㄏㄠ");
+    assert_outgoing_pre_edit("", "你1");
 }
 
 void test_kp_selecting()
@@ -832,15 +866,41 @@ void test_kp_selecting()
     key_press_from_key_sym(IBUS_KP_2, 0);
     assert_outgoing_pre_edit("", "※");
 
+    key_press_from_key_sym(IBUS_KP_1, IBUS_CONTROL_MASK);
+    key_press_from_key_sym(IBUS_KP_1, 0);
+    assert_outgoing_pre_edit("", "※…");
+
 //  TODO: need to check if selkeys are 1234567890
+}
+
+void test_kp_other_keys()
+{
+    TEST_CASE_INIT();
+
+    g_assert(chewing_get_ChiEngMode(self->context) == 1);
+
+    key_press_from_string("su3cl3"); /* 你好 */
+    key_press_from_key_sym(IBUS_KP_Multiply, 0);
+    key_press_from_key_sym(IBUS_KP_Add, 0);
+    key_press_from_key_sym(IBUS_KP_Separator, 0);
+    key_press_from_key_sym(IBUS_KP_Subtract, 0);
+    key_press_from_key_sym(IBUS_KP_Decimal, 0);
+    key_press_from_key_sym(IBUS_KP_Divide, 0);
+    assert_outgoing_pre_edit("", "你好*+,-./");
+
+    /* should remain chi-mode */
+    g_assert(chewing_get_ChiEngMode(self->context) == 1);
 }
 
 void test_keypad()
 {
     test_kp_eng_mode();
-    test_kp_chi_default();
+    test_kp_eng_mode_buffer();
+    test_kp_chi_mode();
+    test_kp_chi_mode_buffer();
     test_kp_chi_incomplete();
     test_kp_selecting();
+    test_kp_other_keys();
 }
 
 gint main(gint argc, gchar ** argv)

--- a/test/IBusChewingPreEdit-test.c
+++ b/test/IBusChewingPreEdit-test.c
@@ -496,6 +496,9 @@ void process_key_down_arrow_test()
     ibus_chewing_pre_edit_set_apply_property_boolean(self,
 						     "plain-zhuyin",
 						     FALSE);
+    ibus_chewing_pre_edit_set_apply_property_boolean(self,
+						     "phrase-choice-from-last",
+						     TRUE);
     key_press_from_string("t/6g4");
     key_press_from_key_sym(IBUS_KEY_Down, 0);
     key_press_from_string("1");


### PR DESCRIPTION
1. 修復：用數字鍵盤輸入數字後不該切換成英文模式
2. 讓 ``key_sym_get_name()`` 和 ``keyHandlingRules[]`` 能處理數字盤上 0~9 以外的按鍵（加減乘除）
3. 修改數字鍵盤行為：組字到一半時按數字鍵盤會結束組字（清空未完成的ㄅㄆㄇ），然後輸入數字
4. 更新 test case