### PR TITLE
Fix GitHub #85: Message of adding userphrase not displayed

### DIFF
--- a/src/IBusChewingEngine-signal.c
+++ b/src/IBusChewingEngine-signal.c
@@ -180,8 +180,8 @@ void parent_update_auxiliary_text(IBusEngine * iEngine,
         (iText) ? iText->text : "NULL", visible);
 #else
     if (!visible || ibus_text_is_empty(iText)) {
-    ibus_engine_hide_auxiliary_text(iEngine);
-    return;
+        ibus_engine_hide_auxiliary_text(iEngine);
+        return;
     }
     ibus_engine_update_auxiliary_text(iEngine, iText, visible);
     ibus_engine_show_auxiliary_text(iEngine);

--- a/src/IBusChewingEngine-signal.c
+++ b/src/IBusChewingEngine-signal.c
@@ -282,7 +282,7 @@ void refresh_aux_text(IBusChewingEngine * self)
     }
 
     /* Make auxText (text to be displayed in auxiliary candidate window).
-     * Use auxText to show messages from libchewing, such as "新增：".
+     * Use auxText to show messages from libchewing, such as "已有：".
      */
     if (chewing_aux_Length(self->icPreEdit->context) > 0) {
         IBUS_CHEWING_LOG(INFO, "update_aux_text() chewing_aux_Length=%x",


### PR DESCRIPTION
* 原本的設計似乎是打算讓組字中的ㄅㄆㄇㄈ顯示在 auxText，但是目前ㄅㄆㄇㄈ已經顯示在預編區，所以移除相關的程式碼。

* 實在不懂 ``ibus_chewing_engine_has_capabilite`` 的作用，但是它又會導致 auxText 停用，所以先移除了。目前還沒遇到異常狀況。