### PR TITLE
Fix auxText and its test case

### DIFF
--- a/src/IBusChewingEngine-signal.c
+++ b/src/IBusChewingEngine-signal.c
@@ -293,7 +293,7 @@ void refresh_aux_text(IBusChewingEngine * self)
         g_free(auxStr);
     } else {
         /* clear out auxText, otherwise it will be displayed continually. */
-        self->auxText = 0;
+        self->auxText = g_object_ref_sink(ibus_text_new_from_static_string(""));
     }
 }
 

--- a/test/ibus-chewing-engine-test.c
+++ b/test/ibus-chewing-engine-test.c
@@ -9,12 +9,11 @@ static IBusChewingEngine *engine = NULL;
 
 IBusChewingEngine *ibus_chewing_engine_new()
 {
-    return (IBusChewingEngine *) g_object_new(IBUS_TYPE_CHEWING_ENGINE,
-					      NULL);
+    return (IBusChewingEngine *) g_object_new(IBUS_TYPE_CHEWING_ENGINE, NULL);
 }
 
 void check_output(const gchar * outgoing, const gchar * preEdit,
-		  const gchar * aux)
+                  const gchar * aux)
 {
     g_assert(engine->outgoingText);
     g_assert(engine->outgoingText->text);
@@ -28,24 +27,43 @@ void check_output(const gchar * outgoing, const gchar * preEdit,
 
 void focus_out_then_focus_in_with_aux_text_test()
 {
-    gboolean cleanBufferFocusOut=ibus_chewing_pre_edit_get_property_boolean(engine->icPreEdit, "clean-buffer-focus-out");
+    gboolean cleanBufferFocusOut = ibus_chewing_pre_edit_get_property_boolean
+        (engine->icPreEdit, "clean-buffer-focus-out");
+
     ibus_chewing_engine_set_capabilite(engine, IBUS_CAP_AUXILIARY_TEXT);
     ibus_chewing_engine_focus_in(engine);
     ibus_chewing_engine_enable(engine);
-    ibus_chewing_engine_process_key_event(IBUS_ENGINE(engine), 'j', 0x24,
-					  0);
-    ibus_chewing_engine_process_key_event(IBUS_ENGINE(engine), 'j', 0x24,
-					  IBUS_RELEASE_MASK);
-    check_output("", "ㄨ", "ㄨ");
+    ibus_chewing_engine_process_key_event(IBUS_ENGINE(engine),
+                                         'j', 0x24, 0);
+    ibus_chewing_engine_process_key_event(IBUS_ENGINE(engine),
+                                         'j', 0x24, IBUS_RELEASE_MASK);
+    ibus_chewing_engine_process_key_event(IBUS_ENGINE(engine),
+                                         '3', 0x04, 0);
+    ibus_chewing_engine_process_key_event(IBUS_ENGINE(engine),
+                                         '3', 0x04, IBUS_RELEASE_MASK);
+    ibus_chewing_engine_process_key_event(IBUS_ENGINE(engine),
+                                         'j', 0x24, 0);
+    ibus_chewing_engine_process_key_event(IBUS_ENGINE(engine),
+                                         'j', 0x24, IBUS_RELEASE_MASK);
+    ibus_chewing_engine_process_key_event(IBUS_ENGINE(engine),
+                                         '3', 0x04, 0);
+    ibus_chewing_engine_process_key_event(IBUS_ENGINE(engine),
+                                         '3', 0x04, IBUS_RELEASE_MASK);
+    ibus_chewing_engine_process_key_event(IBUS_ENGINE(engine),
+                                         '2', 0x03, IBUS_CONTROL_MASK);
+    ibus_chewing_engine_process_key_event(IBUS_ENGINE(engine),
+                                         '2', 0x03, IBUS_RELEASE_MASK);
+    check_output("", "五五", "已有：五五");
 
-    /* focus out should not touch Texts
-     */
+    /* focus out should not touch Texts */
     ibus_chewing_engine_focus_out(engine);
-    g_assert(cleanBufferFocusOut==ibus_chewing_pre_edit_get_property_boolean(engine->icPreEdit, "clean-buffer-focus-out"));
-    if (cleanBufferFocusOut){
-	check_output("", "", "");
-    }else{
-	check_output("", "ㄨ", "ㄨ");
+    g_assert(cleanBufferFocusOut == ibus_chewing_pre_edit_get_property_boolean
+        (engine->icPreEdit, "clean-buffer-focus-out"));
+
+    if (cleanBufferFocusOut) {
+        check_output("", "", "");
+    } else {
+        check_output("", "五五", "已有：五五");
     }
 
     /* all should be clean */


### PR DESCRIPTION
1. 跑測試的時候出現程式記憶體區段錯誤 (core dumped)。似乎是不能用 ``self->auxText = 0`` 來清空，改用 ``ibus_text_new_from_static_string("")`` 就恢復正常了。

2. 現在 auxText 已經不顯示ㄅㄆㄇ，只顯示自訂詞彙的訊息（加入、已有），所以修改了 test case。