### PR TITLE
Remove comparison of unsigned enum expression < 0

### DIFF
--- a/src/IBusChewingEngine-input-events.c
+++ b/src/IBusChewingEngine-input-events.c
@@ -40,8 +40,7 @@ void ibus_chewing_engine_candidate_clicked(IBusEngine * engine,
     IBusChewingEngine *self = IBUS_CHEWING_ENGINE(engine);
     if (is_password(self))
 	return;
-    if (index >= chewing_get_candPerPage(self->icPreEdit->context)
-	|| index < 0) {
+    if (index >= chewing_get_candPerPage(self->icPreEdit->context)) {
 	IBUS_CHEWING_LOG(DEBUG, "candidate_clicked() index out of ranged");
 	return;
     }


### PR DESCRIPTION
 * src/IBusChewingEngine-input-events.c
   index is a guit which cannot be less than zero.