### PR TITLE
Fix memory leaks

### DIFF
--- a/src/GSettingsBackend.c
+++ b/src/GSettingsBackend.c
@@ -190,15 +190,16 @@ gboolean mkdg_g_settings_write_schema_from_spec_array(const gchar *
 /*=== End Schema Writing ===*/
 
 GValue *mkdg_g_settings_read_value(GSettings * settings,
-				   GValue * value, const gchar * key)
+                                   GValue * value, const gchar * key)
 {
     GVariant *confValue = g_settings_get_value(settings, key);
     mkdg_log(DEBUG, "mkdg_g_settings_read_value(-,-,%s)", key);
     if (confValue == NULL) {
-	mkdg_log(ERROR, "mkdg_g_settings_read_value(-,-,%s)", key);
-	return NULL;
+        mkdg_log(ERROR, "mkdg_g_settings_read_value(-,-,%s)", key);
+        return NULL;
     }
     mkdg_g_variant_to_g_value(confValue, value);
+    g_variant_unref(confValue);
     return value;
 }
 

--- a/src/IBusChewingEngine-signal.c
+++ b/src/IBusChewingEngine-signal.c
@@ -189,58 +189,54 @@ void parent_update_auxiliary_text(IBusEngine * iEngine,
 }
 
 IBusText *decorate_pre_edit(IBusChewingPreEdit * icPreEdit,
-			    IBusCapabilite capabilite)
+                            IBusCapabilite capabilite)
 {
     gchar *preEdit = ibus_chewing_pre_edit_get_pre_edit(icPreEdit);
-    IBusText *iText =
-	g_object_ref_sink(ibus_text_new_from_string(preEdit));
-
+    IBusText *iText = ibus_text_new_from_string(preEdit);
     gint chiSymbolCursor = chewing_cursor_Current(icPreEdit->context);
-    IBUS_CHEWING_LOG(DEBUG,
-		     "decorate_pre_edit() cursor=%d preEdit=%s",
-		     chiSymbolCursor, preEdit);
 
+    IBUS_CHEWING_LOG(DEBUG, "decorate_pre_edit() cursor=%d preEdit=%s",
+                     chiSymbolCursor, preEdit);
 
     gint charLen = (gint) g_utf8_strlen(preEdit, -1);
     gint cursorRight = chiSymbolCursor + icPreEdit->bpmfLen;
 
-    IBUS_CHEWING_LOG(DEBUG,
-		     "decorate_pre_edit() charLen=%d cursorRight=%d",
-		     charLen, cursorRight);
+    IBUS_CHEWING_LOG(DEBUG, "decorate_pre_edit() charLen=%d cursorRight=%d",
+                     charLen, cursorRight);
 
     IntervalType it;
     chewing_interval_Enumerate(icPreEdit->context);
     /* Add double lines on chewing interval that contains cursor */
     /* Add single line on other chewing interval */
     while (chewing_interval_hasNext(icPreEdit->context)) {
-	chewing_interval_Get(icPreEdit->context, &it);
-	if (it.from <= chiSymbolCursor && chiSymbolCursor <= it.to) {
-	    ibus_text_append_attribute(iText,
-				       IBUS_ATTR_TYPE_UNDERLINE,
-				       IBUS_ATTR_UNDERLINE_DOUBLE,
-				       it.from, it.to + 1);
-
-	} else {
-	    ibus_text_append_attribute(iText,
-				       IBUS_ATTR_TYPE_UNDERLINE,
-				       IBUS_ATTR_UNDERLINE_SINGLE,
-				       it.from, it.to + 1);
-	}
-
+        chewing_interval_Get(icPreEdit->context, &it);
+        if (it.from <= chiSymbolCursor && chiSymbolCursor <= it.to) {
+            ibus_text_append_attribute(iText,
+                                       IBUS_ATTR_TYPE_UNDERLINE,
+                                       IBUS_ATTR_UNDERLINE_DOUBLE,
+                                       it.from, it.to + 1);
+        } else {
+            ibus_text_append_attribute(iText,
+                                       IBUS_ATTR_TYPE_UNDERLINE,
+                                       IBUS_ATTR_UNDERLINE_SINGLE,
+                                       it.from, it.to + 1);
+        }
     }
 
     if (!mkdg_has_flag(capabilite, IBUS_CAP_SURROUNDING_TEXT)
-	|| !mkdg_has_flag(capabilite, IBUS_CAP_AUXILIARY_TEXT)) {
-	/* Cannot change color when if the client is not capable
-	 * of showing surrounding text or auxiliary text
-	 */
-	return iText;
+        || !mkdg_has_flag(capabilite, IBUS_CAP_AUXILIARY_TEXT)) {
+        /* Cannot change color when if the client is not capable
+         * of showing surrounding text or auxiliary text
+         */
+        return iText;
     }
 
     /* Show current cursor in red */
-    ibus_text_append_attribute(iText, IBUS_ATTR_TYPE_BACKGROUND,
-			       0x00ff0000, chiSymbolCursor,
-			       chiSymbolCursor + 1);
+    ibus_text_append_attribute(iText, 
+                               IBUS_ATTR_TYPE_BACKGROUND,
+                               0x00ff0000,
+                               chiSymbolCursor,
+                               chiSymbolCursor + 1);
 
     return iText;
 }

--- a/src/IBusChewingLookupTable.c
+++ b/src/IBusChewingLookupTable.c
@@ -2,45 +2,43 @@
 #include "IBusChewingLookupTable.h"
 
 IBusLookupTable *ibus_chewing_lookup_table_new(IBusChewingProperties *
-					       iProperties,
-					       ChewingContext * context)
+                                               iProperties,
+                                               ChewingContext * context)
 {
     guint size = mkdg_properties_get_uint_by_key
-	(iProperties->properties, "cand-per-page");
+        (iProperties->properties, "cand-per-page");
     gboolean cursorShow = FALSE;
     gboolean wrapAround = TRUE;
     IBusLookupTable *iTable = ibus_lookup_table_new
-	(size, 0, cursorShow, wrapAround);
+        (size, 0, cursorShow, wrapAround);
 
     ibus_chewing_lookup_table_resize(iTable, iProperties, context);
-    return g_object_ref_sink(iTable);
+    return iTable;
 }
 
-
 void ibus_chewing_lookup_table_resize(IBusLookupTable * iTable,
-				      IBusChewingProperties * iProperties,
-				      ChewingContext * context)
+                                      IBusChewingProperties * iProperties,
+                                      ChewingContext * context)
 {
     gint selKSym[MAX_SELKEY];
     const gchar *selKeyStr =
-	mkdg_properties_get_string_by_key(iProperties->properties,
-					  "sel-keys");
+        mkdg_properties_get_string_by_key(iProperties->properties, "sel-keys");
     guint candPerPage =
-	mkdg_properties_get_uint_by_key(iProperties->properties,
-					"cand-per-page");
+        mkdg_properties_get_uint_by_key(iProperties->properties, "cand-per-page");
 
     int len = MIN(strlen(selKeyStr), MAX_SELKEY);
     len = MIN(len, candPerPage);
     IBusText *iText;
     int i;
     if (iTable != NULL) {
-	ibus_lookup_table_clear(iTable);
-	for (i = 0; i < len; i++) {
-	    selKSym[i] = (gint) selKeyStr[i];
-	    iText = g_object_ref_sink(ibus_text_new_from_unichar
-				      ((gunichar) selKeyStr[i]));
-	    ibus_lookup_table_set_label(iTable, i, iText);
-	}
+        ibus_lookup_table_clear(iTable);
+        for (i = 0; i < len; i++) {
+            selKSym[i] = (gint) selKeyStr[i];
+            iText = g_object_ref_sink(ibus_text_new_from_unichar
+		                  ((gunichar) selKeyStr[i]));
+            ibus_lookup_table_set_label(iTable, i, iText);
+            g_object_unref(iText);
+        }
     }
     chewing_set_candPerPage(context, len);
     chewing_set_selKey(context, selKSym, len);


### PR DESCRIPTION
用 valgrind 分別跑 ``IBusChewingPreEdit-test`` 和 ``ibus-chewing-engine-test`` 兩個檔案，顯示四個地方有 definitely lost，移除 g_object_ref_sink() 或增補 unref 之後再跑一次就解除了。

IBusChewingPreEdit-test 修改前
```
==19740== LEAK SUMMARY:
==19740==    definitely lost: 241,088 bytes in 3,031 blocks
==19740==    indirectly lost: 136,279 bytes in 6,085 blocks
==19740==      possibly lost: 2,856 bytes in 28 blocks
==19740==    still reachable: 241,231 bytes in 1,980 blocks
==19740== ERROR SUMMARY: 134 errors from 134 contexts (suppressed: 0 from 0)
```

IBusChewingPreEdit-test 修改後
```
==14487== LEAK SUMMARY:
==14487==    definitely lost: 112 bytes in 2 blocks
==14487==    indirectly lost: 1,607 bytes in 29 blocks
==14487==      possibly lost: 2,824 bytes in 27 blocks
==14487==    still reachable: 241,222 bytes in 1,980 blocks
```

ibus-chewing-engine-test 修改前
```
==19789== LEAK SUMMARY:
==19789==    definitely lost: 14,856 bytes in 250 blocks
==19789==    indirectly lost: 10,566 bytes in 374 blocks
==19789==      possibly lost: 3,920 bytes in 28 blocks
==19789==    still reachable: 608,272 bytes in 3,034 blocks
==19789== ERROR SUMMARY: 42 errors from 42 contexts (suppressed: 0 from 0)
```

ibus-chewing-engine-test 修改後
```
==14519== LEAK SUMMARY:
==14519==    definitely lost: 96 bytes in 1 blocks
==14519==    indirectly lost: 58 bytes in 1 blocks
==14519==      possibly lost: 3,920 bytes in 28 blocks
==14519==    still reachable: 607,239 bytes in 3,033 blocks
```