### PR TITLE
Fix memory leak in start_component()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -89,39 +89,23 @@ static void start_component(void)
                                        QUOTE_ME(PROJECT_NAME));
     }
 
-    IBusEngineDesc *engineDesc = ibus_engine_desc_new_varargs("name", "chewing",
-                                                              "longname",
-                                                              _("Chewing"),
-                                                              "description",
-                                                              _
-                                                              ("Chinese chewing input method"),
-                                                              "language",
-                                                              "zh_TW",
-                                                              "license",
-                                                              "GPLv2+",
-                                                              "author",
-                                                              _
-                                                              ("Peng Huang, Ding-Yi Chen"),
-                                                              "icon",
-                                                              QUOTE_ME
-                                                              (PRJ_DATA_DIR)
-                                                              "/icons/"
-                                                              QUOTE_ME
-                                                              (PROJECT_NAME)
-                                                              ".png",
-                                                              "layout", "us",
-                                                              "setup",
-                                                              QUOTE_ME
-                                                              (LIBEXEC_DIR)
-                                                              "/ibus-setup-chewing",
-                                                              "version",
-                                                              QUOTE_ME(PRJ_VER),
-                                                              "textdomain",
-                                                              QUOTE_ME
-                                                              (PROJECT_NAME),
-                                                              NULL);
+    IBusEngineDesc *engineDesc =
+        ibus_engine_desc_new_varargs
+            ("name", "chewing",
+             "longname", _("Chewing"),
+             "description", _("Chinese chewing input method"),
+             "language", "zh_TW",
+             "license", "GPLv2+",
+             "author", _("Peng Huang, Ding-Yi Chen"),
+             "icon", QUOTE_ME(PRJ_DATA_DIR)"/icons/"QUOTE_ME(PROJECT_NAME)".png",
+             "layout", "us",
+             "setup", QUOTE_ME(LIBEXEC_DIR)"/ibus-setup-chewing",
+             "version", QUOTE_ME(PRJ_VER),
+             "textdomain", QUOTE_ME(PROJECT_NAME),
+             NULL);
 
     ibus_component_add_engine(component, engineDesc);
+
     factory = ibus_factory_new(ibus_bus_get_connection(bus));
     ibus_factory_add_engine(factory, "chewing", IBUS_TYPE_CHEWING_ENGINE);
 
@@ -132,6 +116,8 @@ static void start_component(void)
     } else {
         ibus_bus_register_component(bus, component);
     }
+
+    g_object_unref(component);
     ibus_main();
 }
 


### PR DESCRIPTION
1. ibus_engine_desc_new_varargs() 部份被 indent 排得太狹窄，反而影響閱讀，所以手動調整。

2. valgrind 顯示在 start_component() 有洩漏，使用 ``g_object_unref`` 來解除。


修改前：
```
（前略）
==9400== 838 (120 direct, 718 indirect) bytes in 1 blocks are definitely lost in loss record 6,241 of 6,369
==9400==    at 0x56833F3: g_type_create_instance (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.4800.1)
==9400==    by 0x5664DF7: ??? (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.4800.1)
==9400==    by 0x5665148: ??? (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.4800.1)
==9400==    by 0x56671B4: g_object_new_valist (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.4800.1)
==9400==    by 0x508CA0C: ibus_component_new_varargs (in /usr/lib/x86_64-linux-gnu/libibus-1.0.so.5.0.511)
==9400==    by 0x508CAFF: ibus_component_new (in /usr/lib/x86_64-linux-gnu/libibus-1.0.so.5.0.511)
==9400==    by 0x4170BD: ??? (in /usr/libexec/ibus-engine-chewing)
==9400==    by 0x417475: main (in /usr/libexec/ibus-engine-chewing)
==9400== 
==9400== LEAK SUMMARY:
==9400==    definitely lost: 216 bytes in 2 blocks
==9400==    indirectly lost: 776 bytes in 29 blocks
==9400==      possibly lost: 142,616 bytes in 135 blocks
==9400==    still reachable: 1,045,952 bytes in 8,241 blocks
```


加上 g_object_unref 之後：
```
==29098== LEAK SUMMARY:
==29098==    definitely lost: 96 bytes in 1 blocks
==29098==    indirectly lost: 58 bytes in 1 blocks
==29098==      possibly lost: 73,504 bytes in 82 blocks
==29098==    still reachable: 1,043,180 bytes in 8,154 blocks
```