### PR TITLE
Remove option "clear pre-edit buffer when focus out"

### DIFF
--- a/src/IBusChewingApplier.c
+++ b/src/IBusChewingApplier.c
@@ -66,14 +66,6 @@ addPhraseDirection_apply_callback(PropertyContext * ctx, gpointer userData)
     return TRUE;
 }
 
-
-gboolean
-cleanBufferFocusOut_apply_callback(PropertyContext * ctx, gpointer userData)
-{
-    return TRUE;
-}
-
-
 gboolean
 easySymbolInput_apply_callback(PropertyContext * ctx, gpointer userData)
 {

--- a/src/IBusChewingEngine-signal.c
+++ b/src/IBusChewingEngine-signal.c
@@ -26,7 +26,6 @@ void ibus_chewing_engine_start(IBusChewingEngine * self)
     ibus_chewing_engine_use_setting(self);
     ibus_chewing_engine_restore_mode(self);
     ibus_chewing_engine_refresh_property_list(self);
-
 }
 
 /**
@@ -72,14 +71,10 @@ void ibus_chewing_engine_focus_in(IBusChewingEngine * self)
 {
     IBUS_CHEWING_LOG(MSG, "* focus_in(): statusFlags=%x",
                      self->_priv->statusFlags);
-    ibus_chewing_engine_start(self);
-    /* Shouldn't have anything to commit when Focus-in */
-    ibus_chewing_pre_edit_clear(self->icPreEdit);
-    refresh_pre_edit_text(self);
-    refresh_aux_text(self);
-    refresh_outgoing_text(self);
 
+    ibus_chewing_engine_start(self);
     ibus_chewing_engine_set_status_flag(self, ENGINE_FLAG_FOCUS_IN);
+
     IBUS_CHEWING_LOG(INFO, "focus_in() statusFlags=%x: return",
                      self->_priv->statusFlags);
 }
@@ -93,13 +88,11 @@ void ibus_chewing_engine_focus_out(IBusChewingEngine * self)
                                           ENGINE_FLAG_PROPERTIES_REGISTERED);
     ibus_chewing_engine_hide_property_list(self);
 
-    if (ibus_chewing_pre_edit_get_property_boolean
-        (self->icPreEdit, "clean-buffer-focus-out")) {
-        /* Clean the buffer when focus out */
-        ibus_chewing_pre_edit_clear(self->icPreEdit);
-        refresh_pre_edit_text(self);
-        refresh_aux_text(self);
-    }
+    /* Clean the buffer when focus out */
+    ibus_chewing_pre_edit_clear(self->icPreEdit);
+    refresh_pre_edit_text(self);
+    refresh_aux_text(self);
+    refresh_outgoing_text(self);
 
     IBUS_CHEWING_LOG(DEBUG, "focus_out(): return");
 }

--- a/src/IBusChewingProperties.c
+++ b/src/IBusChewingProperties.c
@@ -104,14 +104,6 @@ MkdgPropertySpec propSpecs[] = {
      addPhraseDirection_apply_callback, 0,
      N_("Add phrases to the front"), NULL}
     ,
-    {G_TYPE_BOOLEAN, "clean-buffer-focus-out", PAGE_EDITING,
-     N_("Clean pre-edit buffer when focus out"),
-     IBUS_CHEWING_PROPERTIES_SUBSECTION, "0", NULL, NULL, 0, 1,
-     cleanBufferFocusOut_apply_callback, 0,
-     N_
-     ("On: Clean pre-edit buffer when focus out to prevent program crash\n"
-      "Off: Keep what you already type for convenience"), NULL}
-    ,
     {G_TYPE_BOOLEAN, "easy-symbol-input", PAGE_EDITING,
      N_("Easy symbol input"),
      IBUS_CHEWING_PROPERTIES_SUBSECTION, "1", NULL, NULL, 0, 1,

--- a/test/ibus-chewing-engine-test.c
+++ b/test/ibus-chewing-engine-test.c
@@ -27,9 +27,6 @@ void check_output(const gchar * outgoing, const gchar * preEdit,
 
 void focus_out_then_focus_in_with_aux_text_test()
 {
-    gboolean cleanBufferFocusOut = ibus_chewing_pre_edit_get_property_boolean
-        (engine->icPreEdit, "clean-buffer-focus-out");
-
     ibus_chewing_engine_set_capabilite(engine, IBUS_CAP_AUXILIARY_TEXT);
     ibus_chewing_engine_focus_in(engine);
     ibus_chewing_engine_enable(engine);
@@ -51,38 +48,15 @@ void focus_out_then_focus_in_with_aux_text_test()
                                           '2', 0x03, IBUS_RELEASE_MASK);
     check_output("", "五五", "已有：五五");
 
-    /* focus out should not touch Texts */
-    ibus_chewing_engine_focus_out(engine);
-    g_assert(cleanBufferFocusOut == ibus_chewing_pre_edit_get_property_boolean
-             (engine->icPreEdit, "clean-buffer-focus-out"));
-
-    if (cleanBufferFocusOut) {
-        check_output("", "", "");
-    } else {
-        check_output("", "五五", "已有：五五");
-    }
-
     /* all should be clean */
+    ibus_chewing_engine_focus_out(engine);
+    check_output("", "", "");
+
     ibus_chewing_engine_focus_in(engine);
     check_output("", "", "");
 
     ibus_chewing_pre_edit_clear(engine->icPreEdit);
     check_output("", "", "");
-}
-
-void focus_out_then_focus_in_with_aux_text_clean_buffer_on_test()
-{
-    ibus_chewing_pre_edit_save_property_boolean(engine->icPreEdit,
-                                                "clean-buffer-focus-out", TRUE);
-    focus_out_then_focus_in_with_aux_text_test();
-}
-
-void focus_out_then_focus_in_with_aux_text_clean_buffer_off_test()
-{
-    ibus_chewing_pre_edit_save_property_boolean(engine->icPreEdit,
-                                                "clean-buffer-focus-out",
-                                                FALSE);
-    focus_out_then_focus_in_with_aux_text_test();
 }
 
 gint main(gint argc, gchar ** argv)
@@ -95,15 +69,7 @@ gint main(gint argc, gchar ** argv)
     ibus_chewing_pre_edit_set_apply_property_boolean(engine->icPreEdit,
                                                      "plain-zhuyin", FALSE);
 
-    gboolean cleanBufferFocusOut =
-        ibus_chewing_pre_edit_get_property_boolean(engine->icPreEdit,
-                                                   "clean-buffer-focus-out");
-
-    TEST_RUN_THIS(focus_out_then_focus_in_with_aux_text_clean_buffer_off_test);
-    TEST_RUN_THIS(focus_out_then_focus_in_with_aux_text_clean_buffer_on_test);
-    ibus_chewing_pre_edit_save_property_boolean(engine->icPreEdit,
-                                                "clean-buffer-focus-out",
-                                                cleanBufferFocusOut);
+    TEST_RUN_THIS(focus_out_then_focus_in_with_aux_text_test);
 
     return g_test_run();
 }


### PR DESCRIPTION
移除「focus out 時清空緩衝區」這個選項，改為總是清空，因為……

* 目前 ibus-chewing 在 focus out 的時候，似乎不管怎樣都會自動送出緩衝區的內容，如果 buffer 沒清空的話，就會有重複的內容一直留在 buffer 裡，使用者還是要手動清空。

* 簡化使用情境和選項：一般來說，會想要切換焦點就代表輸入完畢、不需要選字了（專心組字、選字）。

* 減少程式崩潰的機會