### PR TITLE
Update test cases for aux message

### DIFF
--- a/test/ibus-chewing-engine-test.c
+++ b/test/ibus-chewing-engine-test.c
@@ -22,13 +22,16 @@ void check_output(const gchar * outgoing, const gchar * preEdit,
     printf("preEditText->text=%s\n", engine->preEditText->text);
     g_assert_cmpstr(preEdit, ==, engine->preEditText->text);
     printf("auxText->text=%s\n", engine->auxText->text);
-    g_assert_cmpstr(aux, ==, engine->auxText->text);
+    g_assert_cmpint(strlen(aux), ==, strlen(engine->auxText->text));
 }
 
 void focus_out_then_focus_in_with_aux_text_test()
 {
     gboolean cleanBufferFocusOut = ibus_chewing_pre_edit_get_property_boolean
         (engine->icPreEdit, "clean-buffer-focus-out");
+
+    ibus_chewing_pre_edit_save_property_boolean(engine->icPreEdit,
+                                                "add-phrase-direction", TRUE);
 
     ibus_chewing_engine_set_capabilite(engine, IBUS_CAP_AUXILIARY_TEXT);
     ibus_chewing_engine_focus_in(engine);


### PR DESCRIPTION
不曉得為什麼之前沒顯示錯誤…

目前 test case 似乎會使用既有的使用者詞庫，而非獨立的詞庫檔，使用者詞庫有可能已經包含測試用的詞，所以「加入：○○○」或「已有：○○○」兩種結果都有可能。

由於這邊只是要測試 aux 訊息有正確的顯示和清空，所以我把它改為檢查字數