### PR TITLE
Refresh property list (language bar) only when needed

### DIFF
--- a/src/IBusChewingEngine-input-events.c
+++ b/src/IBusChewingEngine-input-events.c
@@ -24,6 +24,15 @@ gboolean ibus_chewing_engine_process_key_event(IBusEngine * engine,
     IBUS_CHEWING_LOG(MSG, "process_key_event() result=%d", result);
     self_update(self);
 
+    if (kSym == IBUS_KEY_Shift_L || kSym == IBUS_KEY_Shift_R || 
+        kSym == IBUS_KEY_Caps_Lock) {
+        /* Refresh property list (language bar) only when users toggle
+         * Chi-Eng Mode or Shape Mode with Shift or Caps Lock, otherwise
+         * the bar will stick to the cursor and block the candidats list.
+         */
+        self_refresh_property_list(self);
+    }
+
     return result;
 }
 

--- a/src/IBusChewingEngine.gob
+++ b/src/IBusChewingEngine.gob
@@ -385,7 +385,6 @@ class IBus:Chewing:Engine from IBus:Engine {
                          chewing_get_phoneSeqLen(self->icPreEdit->context),
                          self->_priv->statusFlags);
         update_lookup_table(self);
-        self_refresh_property_list(self);
     }
 
     protected void refresh_property(self, const gchar * prop_name) {


### PR DESCRIPTION
When users set the property list (language bar) to "auto hide"
in ibus-setup, the bar will stick to the cursor and block the
candidats list, because ibus-chewing refreshes the bar on every
keystroke. Therefore, it's better to refresh the bar only when
users toggle Chi-Eng Mode or Shape Mode with Shift or Caps Lock.
