### PR TITLE
Update property list (language bar)

### DIFF
--- a/src/IBusChewingEngine-input-events.c
+++ b/src/IBusChewingEngine-input-events.c
@@ -75,7 +75,7 @@ void ibus_chewing_engine_property_activate(IBusEngine * engine,
                      prop_state);
     Self *self = SELF(engine);
 
-    if (STRING_EQUALS(prop_name, "InputMode")) {
+    if (STRING_EQUALS(prop_name, "chiEng_prop")) {
         /* Toggle Chinese <-> English */
         ibus_chewing_pre_edit_toggle_chi_eng_mode(self->icPreEdit);
         IBUS_CHEWING_LOG(INFO,
@@ -92,11 +92,14 @@ void ibus_chewing_engine_property_activate(IBusEngine * engine,
             }
         }
         self_refresh_property(self, prop_name);
-    } else if (STRING_EQUALS(prop_name, "chewing_alnumSize_prop")) {
+    } else if (STRING_EQUALS(prop_name, "alnumSize_prop")) {
         /* Toggle Full <-> Half */
         chewing_set_ShapeMode(self->icPreEdit->context,
                               !chewing_get_ShapeMode(self->icPreEdit->context));
         self_refresh_property(self, prop_name);
+    } else if (STRING_EQUALS(prop_name, "setup_prop")) {
+        /* open preferences window */
+        system(QUOTE_ME(LIBEXEC_DIR) "/ibus-setup-chewing");
     } else {
         IBUS_CHEWING_LOG(DEBUG,
                          "property_activate(-, %s, %u) not recognized",

--- a/src/IBusChewingEngine-signal.c
+++ b/src/IBusChewingEngine-signal.c
@@ -15,9 +15,11 @@ void ibus_chewing_engine_start(IBusChewingEngine * self)
     if (!ibus_chewing_engine_has_status_flag
         (self, ENGINE_FLAG_PROPERTIES_REGISTERED)) {
         IBUS_ENGINE_GET_CLASS(self)->property_show(IBUS_ENGINE(self),
-                                                   "InputMode");
+                                                   "chiEng_prop");
         IBUS_ENGINE_GET_CLASS(self)->property_show(IBUS_ENGINE(self),
-                                                   "chewing_alnumSize_prop");
+                                                   "alnumSize_prop");
+        IBUS_ENGINE_GET_CLASS(self)->property_show(IBUS_ENGINE(self),
+                                                   "setup_prop");
         ibus_engine_register_properties(IBUS_ENGINE(self), self->prop_list);
         ibus_chewing_engine_set_status_flag(self,
                                             ENGINE_FLAG_PROPERTIES_REGISTERED);

--- a/src/IBusChewingEngine.gob
+++ b/src/IBusChewingEngine.gob
@@ -196,20 +196,41 @@ class IBus:Chewing:Engine from IBus:Engine {
 
     public IBusProperty *chieng_prop = {
         g_object_ref_sink(ibus_property_new
-            ("InputMode", PROP_TYPE_NORMAL,
+            ("chiEng_prop",
+             PROP_TYPE_NORMAL,
              SELF_GET_CLASS(self)->chieng_prop_label_chi,
              NULL,
-             SELF_GET_CLASS(self)->chieng_prop_tooltip_chi,
-             TRUE, TRUE,
-             PROP_STATE_UNCHECKED, NULL))
+             SELF_GET_CLASS(self)->chieng_prop_tooltip,
+             TRUE,
+             TRUE,
+             PROP_STATE_UNCHECKED,
+             NULL))
     } destroywith g_object_unref;
 
     public IBusProperty *alnumSize_prop = {
         g_object_ref_sink(ibus_property_new
-            ("chewing_alnumSize_prop", PROP_TYPE_NORMAL,
-            SELF_GET_CLASS(self)->alnumSize_prop_label_half,
-            NULL, NULL, TRUE, TRUE,
-            PROP_STATE_UNCHECKED, NULL))
+            ("alnumSize_prop",
+             PROP_TYPE_NORMAL,
+             SELF_GET_CLASS(self)->alnumSize_prop_label_half,
+             NULL,
+             SELF_GET_CLASS(self)->alnumSize_prop_tooltip,
+             TRUE,
+             TRUE,
+             PROP_STATE_UNCHECKED,
+             NULL))
+    } destroywith g_object_unref;
+
+    public IBusProperty *setup_prop = {
+        g_object_ref_sink(ibus_property_new
+            ("setup_prop",
+             PROP_TYPE_NORMAL,
+             SELF_GET_CLASS(self)->setup_prop_label,
+             NULL,
+             SELF_GET_CLASS(self)->setup_prop_tooltip,
+             TRUE,
+             TRUE,
+             PROP_STATE_UNCHECKED,
+             NULL))
     } destroywith g_object_unref;
 
     public IBusPropList *prop_list = {
@@ -223,18 +244,14 @@ class IBus:Chewing:Engine from IBus:Engine {
     } destroywith XCloseDisplay;
 
     classwide IBusText *chieng_prop_label_chi = {
-        g_object_ref_sink(ibus_text_new_from_static_string(_("Chi")))
+        g_object_ref_sink(ibus_text_new_from_static_string(_("Chinese Mode")))
     };
     classwide IBusText *chieng_prop_label_eng = {
-        g_object_ref_sink(ibus_text_new_from_static_string(_("Eng")))
+        g_object_ref_sink(ibus_text_new_from_static_string(_("Alphanumeric Mode")))
     };
-    classwide IBusText *chieng_prop_tooltip_chi = {
+    classwide IBusText *chieng_prop_tooltip = {
         g_object_ref_sink(ibus_text_new_from_static_string
-                          (_("Click to switch to English")))
-    };
-    classwide IBusText *chieng_prop_tooltip_eng = {
-        g_object_ref_sink(ibus_text_new_from_static_string
-                          (_("Click to switch to Chinese")))
+                          (_("Click to toggle Chinese/Alphanumeric Mode")))
     };
     classwide IBusText *chieng_prop_symbol_chi = {
         g_object_ref_sink(ibus_text_new_from_static_string("中"))
@@ -242,19 +259,16 @@ class IBus:Chewing:Engine from IBus:Engine {
     classwide IBusText *chieng_prop_symbol_eng = {
         g_object_ref_sink(ibus_text_new_from_static_string("英"))
     };
+
     classwide IBusText *alnumSize_prop_label_full = {
-        g_object_ref_sink(ibus_text_new_from_static_string(_("Full")))
+        g_object_ref_sink(ibus_text_new_from_static_string(_("Fullwidth Form")))
     };
     classwide IBusText *alnumSize_prop_label_half = {
-        g_object_ref_sink(ibus_text_new_from_static_string(_("Half")))
+        g_object_ref_sink(ibus_text_new_from_static_string(_("Halfwidth Form")))
     };
-    classwide IBusText *alnumSize_prop_tooltip_full = {
+    classwide IBusText *alnumSize_prop_tooltip = {
         g_object_ref_sink(ibus_text_new_from_static_string
-                          (_("Click to switch to Half")))
-    };
-    classwide IBusText *alnumSize_prop_tooltip_half = {
-        g_object_ref_sink(ibus_text_new_from_static_string
-                          (_("Click to switch to Full")))
+                          (_("Click to toggle Halfwidth/Fullwidth Form")))
     };
     classwide IBusText *alnumSize_prop_symbol_full = {
         g_object_ref_sink(ibus_text_new_from_static_string("全"))
@@ -262,6 +276,18 @@ class IBus:Chewing:Engine from IBus:Engine {
     classwide IBusText *alnumSize_prop_symbol_half = {
         g_object_ref_sink(ibus_text_new_from_static_string("半"))
     };
+
+    classwide IBusText *setup_prop_label = {
+        g_object_ref_sink(ibus_text_new_from_static_string(_("Chewing Preferences")))
+    };
+    classwide IBusText *setup_prop_tooltip = {
+        g_object_ref_sink(ibus_text_new_from_static_string
+                          (_("Click to configure IBus-Chewing")))
+    };
+    classwide IBusText *setup_prop_symbol = {
+        g_object_ref_sink(ibus_text_new_from_static_string("訂"))
+    };
+
     classwide IBusText *emptyText = {
         g_object_ref_sink(ibus_text_new_from_static_string(""))
     };
@@ -314,6 +340,7 @@ class IBus:Chewing:Engine from IBus:Engine {
         /* init properties */
         ibus_prop_list_append(self->prop_list, self->chieng_prop);
         ibus_prop_list_append(self->prop_list, self->alnumSize_prop);
+        ibus_prop_list_append(self->prop_list, self->setup_prop);
 
         ibus_chewing_engine_set_status_flag(self, ENGINE_FLAG_INITIALIZED);
 
@@ -368,9 +395,9 @@ class IBus:Chewing:Engine from IBus:Engine {
                 }
             } else if (ibus_chewing_pre_edit_has_flag(self->icPreEdit, FLAG_SYNC_FROM_KEYBOARD)) {
                 IBUS_CHEWING_LOG(DEBUG, "restore_mode() FLAG_SYNC_FROM_KEYBOARD");
-                chewing_set_ChiEngMode(self->icPreEdit->context, (is_caps_lock(self))? 0: CHINESE_MODE);
+                chewing_set_ChiEngMode(self->icPreEdit->context, (is_caps_lock(self)) ? 0 : CHINESE_MODE);
             }
-            self_refresh_property(self, "InputMode");
+            self_refresh_property(self, "chiEng_prop");
         }
     }
 
@@ -396,58 +423,45 @@ class IBus:Chewing:Engine from IBus:Engine {
             ibus_chewing_systray_chi_eng_icon_refresh_value(self);
         }
 
-        if (STRING_EQUALS(prop_name, "InputMode")) {
+        if (STRING_EQUALS(prop_name, "chiEng_prop")) {
 
-            if (ibus_chewing_pre_edit_get_chi_eng_mode(self->icPreEdit)) {
-                /* Chinese  */
-                ibus_property_set_label(self->chieng_prop,
-                                        SELF_GET_CLASS(self)->chieng_prop_label_chi);
-                ibus_property_set_tooltip(self->chieng_prop,
-                                          SELF_GET_CLASS(self)->chieng_prop_tooltip_chi);
+            ibus_property_set_label(self->chieng_prop,
+                ibus_chewing_pre_edit_get_chi_eng_mode(self->icPreEdit) ?
+                SELF_GET_CLASS(self)->chieng_prop_label_chi :
+                SELF_GET_CLASS(self)->chieng_prop_label_eng);
+
 #if IBUS_CHECK_VERSION(1, 5, 0)
-                ibus_property_set_symbol(self->chieng_prop,
-                                         SELF_GET_CLASS(self)->chieng_prop_symbol_chi);
+            ibus_property_set_symbol(self->chieng_prop,
+                ibus_chewing_pre_edit_get_chi_eng_mode(self->icPreEdit) ?
+                SELF_GET_CLASS(self)->chieng_prop_symbol_chi :
+                SELF_GET_CLASS(self)->chieng_prop_symbol_eng);
 #endif
-            } else {
-                /* English  */
-                ibus_property_set_label(self->chieng_prop,
-                                        SELF_GET_CLASS(self)->chieng_prop_label_eng);
-                ibus_property_set_tooltip(self->chieng_prop,
-                                          SELF_GET_CLASS(self)->chieng_prop_tooltip_eng);
-#if IBUS_CHECK_VERSION(1, 5, 0)
-                ibus_property_set_symbol(self->chieng_prop,
-                                         SELF_GET_CLASS(self)->chieng_prop_symbol_eng);
-#endif
-            }
 
             ibus_engine_update_property(IBUS_ENGINE(self), self->chieng_prop);
 
-        } else if (STRING_EQUALS(prop_name, "chewing_alnumSize_prop")) {
+        } else if (STRING_EQUALS(prop_name, "alnumSize_prop")) {
 
-            if (chewing_get_ShapeMode(self->icPreEdit->context)) {
-                /* Full-Sized Shape */
-                ibus_property_set_label(self->alnumSize_prop,
-                                        SELF_GET_CLASS(self)->alnumSize_prop_label_full);
-                ibus_property_set_tooltip(self->alnumSize_prop,
-                                          SELF_GET_CLASS(self)->alnumSize_prop_tooltip_full);
+            ibus_property_set_label(self->alnumSize_prop,
+                chewing_get_ShapeMode(self->icPreEdit->context) ?
+                SELF_GET_CLASS(self)->alnumSize_prop_label_full :
+                SELF_GET_CLASS(self)->alnumSize_prop_label_half);
+
 #if IBUS_CHECK_VERSION(1, 5, 0)
-                ibus_property_set_symbol(self->alnumSize_prop,
-                                          SELF_GET_CLASS(self)->alnumSize_prop_symbol_full);
+            ibus_property_set_symbol(self->alnumSize_prop,
+                chewing_get_ShapeMode(self->icPreEdit->context) ?
+                SELF_GET_CLASS(self)->alnumSize_prop_symbol_full :
+                SELF_GET_CLASS(self)->alnumSize_prop_symbol_half);
 #endif
-            } else {
-                /* Half-Sized Shape */
-                ibus_property_set_label(self->alnumSize_prop,
-                                        SELF_GET_CLASS(self)->alnumSize_prop_label_half);
-                ibus_property_set_tooltip(self->alnumSize_prop,
-                                          SELF_GET_CLASS(self)->alnumSize_prop_tooltip_half);
-#if IBUS_CHECK_VERSION(1, 5, 0)
-                ibus_property_set_symbol(self->alnumSize_prop,
-                                          SELF_GET_CLASS(self)->alnumSize_prop_symbol_half);
-#endif
-            }
 
             if (self->_priv->statusFlags & ENGINE_FLAG_PROPERTIES_REGISTERED)
-                ibus_engine_update_property(IBUS_ENGINE(self),self->alnumSize_prop);
+                ibus_engine_update_property(IBUS_ENGINE(self), self->alnumSize_prop);
+
+        } else if (STRING_EQUALS(prop_name, "setup_prop")) {
+#if IBUS_CHECK_VERSION(1, 5, 0)
+            ibus_property_set_symbol(self->setup_prop,
+                                      SELF_GET_CLASS(self)->setup_prop_symbol);
+#endif
+            ibus_engine_update_property(IBUS_ENGINE(self), self->setup_prop);
         }
 #endif
     }
@@ -460,8 +474,9 @@ class IBus:Chewing:Engine from IBus:Engine {
      */
     public void refresh_property_list(self) {
 #ifndef UNIT_TEST
-        self_refresh_property(self, "InputMode");
-        self_refresh_property(self, "chewing_alnumSize_prop");
+        self_refresh_property(self, "chiEng_prop");
+        self_refresh_property(self, "alnumSize_prop");
+        self_refresh_property(self, "setup_prop");
 #endif
     }
 
@@ -474,15 +489,17 @@ class IBus:Chewing:Engine from IBus:Engine {
     public void hide_property_list(self) {
 #ifndef UNIT_TEST
         IBUS_ENGINE_GET_CLASS(self)->property_hide(IBUS_ENGINE(self),
-                                                   "chewing_alnumSize_prop");
+                                                   "alnumSize_prop");
 #endif
     }
 
     private IBusProperty *get_ibus_property_by_name(self, const gchar * prop_name) {
-        if (STRING_EQUALS(prop_name, "InputMode")) {
+        if (STRING_EQUALS(prop_name, "chiEng_prop")) {
             return self->chieng_prop;
-        } else if (STRING_EQUALS(prop_name, "chewing_alnumSize_prop")) {
+        } else if (STRING_EQUALS(prop_name, "alnumSize_prop")) {
             return self->alnumSize_prop;
+        } else if (STRING_EQUALS(prop_name, "setup_prop")) {
+            return self->setup_prop;
         }
         IBUS_CHEWING_LOG(MSG, "get_ibus_property_by_name(%s): NULL is returned", prop_name);
         return NULL;

--- a/src/IBusChewingSystray.c
+++ b/src/IBusChewingSystray.c
@@ -127,6 +127,7 @@ void ibus_chewing_systray_chi_eng_toggle_callback(IBusChewingSystrayIcon *
 
     ibus_chewing_pre_edit_toggle_chi_eng_mode(iEngine->icPreEdit);
     ibus_chewing_systray_chi_eng_icon_refresh_value(iEngine);
+    ibus_chewing_engine_refresh_property_list(iEngine);
 }
 
 /**
@@ -139,6 +140,7 @@ void ibus_chewing_systray_full_half_toggle_callback(IBusChewingSystrayIcon
 
     ibus_chewing_pre_edit_toggle_full_half_mode(iEngine->icPreEdit);
     ibus_chewing_systray_chi_eng_icon_refresh_value(iEngine);
+    ibus_chewing_engine_refresh_property_list(iEngine);
 }
 
 IBusChewingSystrayIcon


### PR DESCRIPTION
This commit contains the following modifications:

1. Fix: the property list (language bar) does not update when
toggling Chi/Eng Mode or Fullwidth/Halfwidth Shape via the
systray icon.

2. Add a setup button to the ibus indicator (and the language
bar), so that users can open the setup window more quickly.
In order to have consistent style with other buttons on
bar, use property symbol instead of icon.

3. Make the naming of prop_name more consistent:
"chiEng_prop", "alnumSize_prop", and "setup_prop".

4. Update property labels and tooltips.