### PR TITLE
Update pre-edit and aux text after commit_text ()

### DIFF
--- a/src/IBusChewingEngine.gob
+++ b/src/IBusChewingEngine.gob
@@ -403,9 +403,9 @@ class IBus:Chewing:Engine from IBus:Engine {
 
     protected void update(self) {
         IBUS_CHEWING_LOG(DEBUG, "update() statusFlags=%x", self->_priv->statusFlags);
+        commit_text(self);
         update_pre_edit_text(self);
         update_aux_text(self);
-        commit_text(self);
 
         IBUS_CHEWING_LOG(DEBUG,
                          "update() nPhoneSeq=%d statusFlags=%x",


### PR DESCRIPTION
預編區額滿、自動送出的時候，預編區會看起來像是在閃爍。仔細觀察可發現，在按下按鍵、自動送出的那瞬間，預邊區的文字會消失，然後才又出現，這個現象在 chromium 的網址列特別明顯。

將 ``commit_text(self)`` 往前挪，這個現象就消失了。