### PR TITLE
Ignore keystrokes in English mode

### DIFF
--- a/src/IBusChewingEngine-input-events.c
+++ b/src/IBusChewingEngine-input-events.c
@@ -75,7 +75,7 @@ void ibus_chewing_engine_property_activate(IBusEngine * engine,
                      prop_state);
     Self *self = SELF(engine);
 
-    if (STRING_EQUALS(prop_name, "chiEng_prop")) {
+    if (STRING_EQUALS(prop_name, "InputMode")) {
         /* Toggle Chinese <-> English */
         ibus_chewing_pre_edit_toggle_chi_eng_mode(self->icPreEdit);
         IBUS_CHEWING_LOG(INFO,
@@ -92,7 +92,7 @@ void ibus_chewing_engine_property_activate(IBusEngine * engine,
             }
         }
         self_refresh_property(self, prop_name);
-    } else if (STRING_EQUALS(prop_name, "alnumSize_prop")) {
+    } else if (STRING_EQUALS(prop_name, "AlnumSize")) {
         /* Toggle Full <-> Half */
         chewing_set_ShapeMode(self->icPreEdit->context,
                               !chewing_get_ShapeMode(self->icPreEdit->context));

--- a/src/IBusChewingEngine-signal.c
+++ b/src/IBusChewingEngine-signal.c
@@ -15,9 +15,9 @@ void ibus_chewing_engine_start(IBusChewingEngine * self)
     if (!ibus_chewing_engine_has_status_flag
         (self, ENGINE_FLAG_PROPERTIES_REGISTERED)) {
         IBUS_ENGINE_GET_CLASS(self)->property_show(IBUS_ENGINE(self),
-                                                   "chiEng_prop");
+                                                   "InputMode");
         IBUS_ENGINE_GET_CLASS(self)->property_show(IBUS_ENGINE(self),
-                                                   "alnumSize_prop");
+                                                   "AlnumSize");
         IBUS_ENGINE_GET_CLASS(self)->property_show(IBUS_ENGINE(self),
                                                    "setup_prop");
         ibus_engine_register_properties(IBUS_ENGINE(self), self->prop_list);

--- a/src/IBusChewingEngine.gob
+++ b/src/IBusChewingEngine.gob
@@ -200,26 +200,28 @@ class IBus:Chewing:Engine from IBus:Engine {
 
     private ChewingInputStyle inputStyle;
 
-    public IBusProperty *chieng_prop = {
+    /* Do not rename this "InputMode" property, 
+     * otherwise the language indicator on gnome-shell cannot work properly. */
+    public IBusProperty *InputMode = {
         g_object_ref_sink(ibus_property_new
-            ("chiEng_prop",
+            ("InputMode",
              PROP_TYPE_NORMAL,
-             SELF_GET_CLASS(self)->chieng_prop_label_chi,
+             SELF_GET_CLASS(self)->InputMode_label_chi,
              NULL,
-             SELF_GET_CLASS(self)->chieng_prop_tooltip,
+             SELF_GET_CLASS(self)->InputMode_tooltip,
              TRUE,
              TRUE,
              PROP_STATE_UNCHECKED,
              NULL))
     } destroywith g_object_unref;
 
-    public IBusProperty *alnumSize_prop = {
+    public IBusProperty *AlnumSize = {
         g_object_ref_sink(ibus_property_new
-            ("alnumSize_prop",
+            ("AlnumSize",
              PROP_TYPE_NORMAL,
-             SELF_GET_CLASS(self)->alnumSize_prop_label_half,
+             SELF_GET_CLASS(self)->AlnumSize_label_half,
              NULL,
-             SELF_GET_CLASS(self)->alnumSize_prop_tooltip,
+             SELF_GET_CLASS(self)->AlnumSize_tooltip,
              TRUE,
              TRUE,
              PROP_STATE_UNCHECKED,
@@ -249,42 +251,42 @@ class IBus:Chewing:Engine from IBus:Engine {
         XOpenDisplay(NULL)
     } destroywith XCloseDisplay;
 
-    classwide IBusText *chieng_prop_label_chi = {
+    classwide IBusText *InputMode_label_chi = {
         g_object_ref_sink(ibus_text_new_from_static_string(_("Chinese Mode")))
     };
-    classwide IBusText *chieng_prop_label_eng = {
+    classwide IBusText *InputMode_label_eng = {
         g_object_ref_sink(ibus_text_new_from_static_string(_("Alphanumeric Mode")))
     };
-    classwide IBusText *chieng_prop_tooltip = {
+    classwide IBusText *InputMode_tooltip = {
         g_object_ref_sink(ibus_text_new_from_static_string
                           (_("Click to toggle Chinese/Alphanumeric Mode")))
     };
-    classwide IBusText *chieng_prop_symbol_chi = {
+    classwide IBusText *InputMode_symbol_chi = {
         g_object_ref_sink(ibus_text_new_from_static_string("中"))
     };
-    classwide IBusText *chieng_prop_symbol_eng = {
+    classwide IBusText *InputMode_symbol_eng = {
         g_object_ref_sink(ibus_text_new_from_static_string("英"))
     };
 
-    classwide IBusText *alnumSize_prop_label_full = {
+    classwide IBusText *AlnumSize_label_full = {
         g_object_ref_sink(ibus_text_new_from_static_string(_("Fullwidth Form")))
     };
-    classwide IBusText *alnumSize_prop_label_half = {
+    classwide IBusText *AlnumSize_label_half = {
         g_object_ref_sink(ibus_text_new_from_static_string(_("Halfwidth Form")))
     };
-    classwide IBusText *alnumSize_prop_tooltip = {
+    classwide IBusText *AlnumSize_tooltip = {
         g_object_ref_sink(ibus_text_new_from_static_string
                           (_("Click to toggle Halfwidth/Fullwidth Form")))
     };
-    classwide IBusText *alnumSize_prop_symbol_full = {
+    classwide IBusText *AlnumSize_symbol_full = {
         g_object_ref_sink(ibus_text_new_from_static_string("全"))
     };
-    classwide IBusText *alnumSize_prop_symbol_half = {
+    classwide IBusText *AlnumSize_symbol_half = {
         g_object_ref_sink(ibus_text_new_from_static_string("半"))
     };
 
     classwide IBusText *setup_prop_label = {
-        g_object_ref_sink(ibus_text_new_from_static_string(_("Chewing Preferences")))
+        g_object_ref_sink(ibus_text_new_from_static_string(_("IBus-Chewing Preferences")))
     };
     classwide IBusText *setup_prop_tooltip = {
         g_object_ref_sink(ibus_text_new_from_static_string
@@ -344,8 +346,8 @@ class IBus:Chewing:Engine from IBus:Engine {
         self->icPreEdit->engine = IBUS_ENGINE(self);
 
         /* init properties */
-        ibus_prop_list_append(self->prop_list, self->chieng_prop);
-        ibus_prop_list_append(self->prop_list, self->alnumSize_prop);
+        ibus_prop_list_append(self->prop_list, self->InputMode);
+        ibus_prop_list_append(self->prop_list, self->AlnumSize);
         ibus_prop_list_append(self->prop_list, self->setup_prop);
 
         ibus_chewing_engine_set_status_flag(self, ENGINE_FLAG_INITIALIZED);
@@ -403,7 +405,7 @@ class IBus:Chewing:Engine from IBus:Engine {
                 IBUS_CHEWING_LOG(DEBUG, "restore_mode() FLAG_SYNC_FROM_KEYBOARD");
                 chewing_set_ChiEngMode(self->icPreEdit->context, (is_caps_lock(self)) ? 0 : CHINESE_MODE);
             }
-            self_refresh_property(self, "chiEng_prop");
+            self_refresh_property(self, "InputMode");
         }
     }
 
@@ -429,38 +431,38 @@ class IBus:Chewing:Engine from IBus:Engine {
             ibus_chewing_systray_chi_eng_icon_refresh_value(self);
         }
 
-        if (STRING_EQUALS(prop_name, "chiEng_prop")) {
+        if (STRING_EQUALS(prop_name, "InputMode")) {
 
-            ibus_property_set_label(self->chieng_prop,
+            ibus_property_set_label(self->InputMode,
                 ibus_chewing_pre_edit_get_chi_eng_mode(self->icPreEdit) ?
-                SELF_GET_CLASS(self)->chieng_prop_label_chi :
-                SELF_GET_CLASS(self)->chieng_prop_label_eng);
+                SELF_GET_CLASS(self)->InputMode_label_chi :
+                SELF_GET_CLASS(self)->InputMode_label_eng);
 
 #if IBUS_CHECK_VERSION(1, 5, 0)
-            ibus_property_set_symbol(self->chieng_prop,
+            ibus_property_set_symbol(self->InputMode,
                 ibus_chewing_pre_edit_get_chi_eng_mode(self->icPreEdit) ?
-                SELF_GET_CLASS(self)->chieng_prop_symbol_chi :
-                SELF_GET_CLASS(self)->chieng_prop_symbol_eng);
+                SELF_GET_CLASS(self)->InputMode_symbol_chi :
+                SELF_GET_CLASS(self)->InputMode_symbol_eng);
 #endif
 
-            ibus_engine_update_property(IBUS_ENGINE(self), self->chieng_prop);
+            ibus_engine_update_property(IBUS_ENGINE(self), self->InputMode);
 
-        } else if (STRING_EQUALS(prop_name, "alnumSize_prop")) {
+        } else if (STRING_EQUALS(prop_name, "AlnumSize")) {
 
-            ibus_property_set_label(self->alnumSize_prop,
+            ibus_property_set_label(self->AlnumSize,
                 chewing_get_ShapeMode(self->icPreEdit->context) ?
-                SELF_GET_CLASS(self)->alnumSize_prop_label_full :
-                SELF_GET_CLASS(self)->alnumSize_prop_label_half);
+                SELF_GET_CLASS(self)->AlnumSize_label_full :
+                SELF_GET_CLASS(self)->AlnumSize_label_half);
 
 #if IBUS_CHECK_VERSION(1, 5, 0)
-            ibus_property_set_symbol(self->alnumSize_prop,
+            ibus_property_set_symbol(self->AlnumSize,
                 chewing_get_ShapeMode(self->icPreEdit->context) ?
-                SELF_GET_CLASS(self)->alnumSize_prop_symbol_full :
-                SELF_GET_CLASS(self)->alnumSize_prop_symbol_half);
+                SELF_GET_CLASS(self)->AlnumSize_symbol_full :
+                SELF_GET_CLASS(self)->AlnumSize_symbol_half);
 #endif
 
             if (self->_priv->statusFlags & ENGINE_FLAG_PROPERTIES_REGISTERED)
-                ibus_engine_update_property(IBUS_ENGINE(self), self->alnumSize_prop);
+                ibus_engine_update_property(IBUS_ENGINE(self), self->AlnumSize);
 
         } else if (STRING_EQUALS(prop_name, "setup_prop")) {
 #if IBUS_CHECK_VERSION(1, 5, 0)
@@ -480,8 +482,8 @@ class IBus:Chewing:Engine from IBus:Engine {
      */
     public void refresh_property_list(self) {
 #ifndef UNIT_TEST
-        self_refresh_property(self, "chiEng_prop");
-        self_refresh_property(self, "alnumSize_prop");
+        self_refresh_property(self, "InputMode");
+        self_refresh_property(self, "AlnumSize");
         self_refresh_property(self, "setup_prop");
 #endif
     }
@@ -495,15 +497,15 @@ class IBus:Chewing:Engine from IBus:Engine {
     public void hide_property_list(self) {
 #ifndef UNIT_TEST
         IBUS_ENGINE_GET_CLASS(self)->property_hide(IBUS_ENGINE(self),
-                                                   "alnumSize_prop");
+                                                   "AlnumSize");
 #endif
     }
 
     private IBusProperty *get_ibus_property_by_name(self, const gchar * prop_name) {
-        if (STRING_EQUALS(prop_name, "chiEng_prop")) {
-            return self->chieng_prop;
-        } else if (STRING_EQUALS(prop_name, "alnumSize_prop")) {
-            return self->alnumSize_prop;
+        if (STRING_EQUALS(prop_name, "InputMode")) {
+            return self->InputMode;
+        } else if (STRING_EQUALS(prop_name, "AlnumSize")) {
+            return self->AlnumSize;
         } else if (STRING_EQUALS(prop_name, "setup_prop")) {
             return self->setup_prop;
         }

--- a/src/IBusChewingPreEdit-private.h
+++ b/src/IBusChewingPreEdit-private.h
@@ -59,6 +59,7 @@
 #    define filter_modifiers(allowed) KeyModifiers maskedMod = modifiers_mask(unmaskedMod); \
 							if ( (maskedMod) & (~(allowed))){ return EVENT_RESPONSE_IGNORE; }
 #    define absorb_when_release if (event_is_released(unmaskedMod)) { return EVENT_RESPONSE_ABSORB; }
+#    define ignore_when_release if (event_is_released(unmaskedMod)) { return EVENT_RESPONSE_IGNORE; }
 #    define ignore_when_buffer_is_empty if (buffer_is_empty) { return EVENT_RESPONSE_IGNORE; }
 #    define ignore_when_buffer_is_empty_and_table_not_showing if (buffer_is_empty && !table_is_showing) { return EVENT_RESPONSE_IGNORE; }
 

--- a/test/IBusChewingPreEdit-test.c
+++ b/test/IBusChewingPreEdit-test.c
@@ -372,6 +372,7 @@ void self_handle_key_sym_default_test()
     assert_outgoing_pre_edit("", "ㄆ");
     ibus_chewing_pre_edit_clear(self);
 
+#if 0
     /*=== Test default-english-case handling ===*/
     ibus_chewing_pre_edit_set_chi_eng_mode(self, FALSE);
     ibus_chewing_pre_edit_set_apply_property_string(self,
@@ -400,6 +401,8 @@ void self_handle_key_sym_default_test()
     assert_outgoing_pre_edit("aaAAaaAA", "");
 
     ibus_chewing_pre_edit_clear(self);
+#endif
+
     assert_outgoing_pre_edit("", "");
 }
 
@@ -451,7 +454,7 @@ void process_key_text_with_symbol_test()
 }
 
 /* Mix english and chinese */
-/* " 這是ibus-chewing 輸入法"*/
+/* "這是ibus-chewing 輸入法"*/
 void process_key_mix_test()
 {
     TEST_CASE_INIT();
@@ -534,27 +537,26 @@ void process_key_shift_and_caps_test()
     ibus_chewing_pre_edit_set_apply_property_boolean(self,
                                                      "capslock-toggle-chinese",
                                                      TRUE);
+    ibus_chewing_pre_edit_set_apply_property_int(self,
+                                                 "max-chi-symbol-len", 33);
     g_assert(ibus_chewing_pre_edit_get_chi_eng_mode(self));
 
     key_press_from_string("ji3ul4fm4 ");
-    key_press_from_key_sym(IBUS_KEY_Return, 0);
-    assert_outgoing_pre_edit("我要去 ", "");
+    assert_outgoing_pre_edit("", "我要去 ");
 
     /* Shift: change to Eng-Mode */
     key_press_from_key_sym(IBUS_KEY_Shift_L, 0);
     g_assert(!ibus_chewing_pre_edit_get_chi_eng_mode(self));
     key_press_from_key_sym(IBUS_KEY_B, IBUS_SHIFT_MASK);        /* B */
     key_press_from_string("risbane ");
-    key_press_from_key_sym(IBUS_KEY_Return, 0);
-    assert_outgoing_pre_edit("我要去 Brisbane ", "");
+    assert_outgoing_pre_edit("", "我要去 Brisbane ");
 
     /* Caps Lock ON: change to Chi-Mode */
     key_press_from_key_sym(IBUS_KEY_Caps_Lock, 0);
     g_assert(ibus_chewing_pre_edit_get_chi_eng_mode(self));
     key_press_from_string("xk7");
     key_press_from_key_sym(IBUS_KEY_greater, IBUS_SHIFT_MASK);
-    key_press_from_key_sym(IBUS_KEY_Return, 0);
-    assert_outgoing_pre_edit("我要去 Brisbane 了。", "");
+    assert_outgoing_pre_edit("", "我要去 Brisbane 了。");
 
     /* Caps Lock OFF: change to Eng-Mode */
     key_press_from_key_sym(IBUS_KEY_Caps_Lock, 0);
@@ -566,8 +568,7 @@ void process_key_shift_and_caps_test()
     key_press_from_key_sym(IBUS_KEY_Shift_L, 0);
     g_assert(ibus_chewing_pre_edit_get_chi_eng_mode(self));
     key_press_from_string("cl3a87");
-    key_press_from_key_sym(IBUS_KEY_Return, 0);
-    assert_outgoing_pre_edit("我要去 Brisbane 了。Daddy 好嗎", "");
+    assert_outgoing_pre_edit("", "我要去 Brisbane 了。Daddy 好嗎");
 
     ibus_chewing_pre_edit_clear(self);
     assert_outgoing_pre_edit("", "");
@@ -658,11 +659,11 @@ void plain_zhuyin_shift_symbol_test()
     /* String is bypass in English mode */
     key_press_from_string("4321-9876 ");
 
-    assert_outgoing_pre_edit("你好，打電話；4321-9876 ", "");
+    assert_outgoing_pre_edit("你好，打電話；", "");
     key_press_from_key_sym(IBUS_KEY_Shift_L, IBUS_SHIFT_MASK);
     /* "來訂餐" */
     key_press_from_string("x9612u/42h0 2");
-    assert_outgoing_pre_edit("你好，打電話；4321-9876 來訂餐", "");
+    assert_outgoing_pre_edit("你好，打電話；來訂餐", "");
 
     ibus_chewing_pre_edit_clear(self);
     assert_outgoing_pre_edit("", "");
@@ -772,6 +773,7 @@ void test_ctrl_1_open_candidate_list()
 
     key_press_from_key_sym(IBUS_KEY_1, IBUS_CONTROL_MASK);
     g_assert(ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
+    key_press_from_key_sym(IBUS_KEY_Escape, 0);
 }
 
 void test_kp_eng_mode()
@@ -786,7 +788,7 @@ void test_kp_eng_mode()
     key_press_from_key_sym(IBUS_KP_1, 0);
     key_press_from_key_sym(IBUS_KEY_KP_9, 0);
     key_press_from_key_sym(IBUS_KP_0, 0);
-    assert_outgoing_pre_edit("190", "");
+    assert_outgoing_pre_edit("", "");
 }
 
 void test_kp_eng_mode_buffer()
@@ -815,7 +817,7 @@ void test_kp_chi_mode()
     key_press_from_key_sym(IBUS_KP_1, 0);
     key_press_from_key_sym(IBUS_KEY_KP_9, 0);
     key_press_from_key_sym(IBUS_KP_0, 0);
-    assert_outgoing_pre_edit("190", "");
+    assert_outgoing_pre_edit("", "");
 
     /* should remain chi-mode */
     g_assert(chewing_get_ChiEngMode(self->context) == 1);


### PR DESCRIPTION
Some users take the temporary English mode as an alternative to disabling IM or
switching to default keyboard layout. For some some applications (e.g. games,
or the 注音 input tool in google translator), we'll need to let the key evets
pass directly, without being processed by ibus-chewing/libchwing.

Test cases update.

This should fix GitHub Issue #143, #144 