### PR TITLE
Space key to turn pages and switch length of candidate list

### DIFF
--- a/src/IBusChewingApplier.c
+++ b/src/IBusChewingApplier.c
@@ -195,3 +195,9 @@ gboolean plainZhuyin_apply_callback(PropertyContext * ctx, gpointer userData)
     /* Use MkdgProperty directly, no need to call IBusChewingEngine */
     return TRUE;
 }
+
+gboolean verticalLookupTable_apply_callback(PropertyContext * ctx, gpointer userData)
+{
+    /* Use MkdgProperty directly, no need to call IBusChewingEngine */
+    return TRUE;
+}

--- a/src/IBusChewingLookupTable.c
+++ b/src/IBusChewingLookupTable.c
@@ -1,5 +1,6 @@
 #include "IBusChewingUtil.h"
 #include "IBusChewingLookupTable.h"
+#include "MakerDialogProperty.h"
 
 IBusLookupTable *ibus_chewing_lookup_table_new(IBusChewingProperties *
                                                iProperties,
@@ -12,6 +13,7 @@ IBusLookupTable *ibus_chewing_lookup_table_new(IBusChewingProperties *
         (size, 0, cursorShow, wrapAround);
 
     ibus_chewing_lookup_table_resize(iTable, iProperties, context);
+
     return iTable;
 }
 
@@ -46,6 +48,12 @@ void ibus_chewing_lookup_table_resize(IBusLookupTable * iTable,
     }
     chewing_set_candPerPage(context, len);
     chewing_set_selKey(context, selKSym, len);
+
+    gboolean verticalLookupTable =
+        mkdg_properties_get_boolean_by_key(iProperties->properties,
+                                                   "vertical-lookup-table");
+
+    ibus_lookup_table_set_orientation(iTable, verticalLookupTable);
 }
 
 guint ibus_chewing_lookup_table_update(IBusLookupTable * iTable,

--- a/src/IBusChewingPreEdit.c
+++ b/src/IBusChewingPreEdit.c
@@ -462,22 +462,67 @@ EventResponse self_handle_shift(IBusChewingPreEdit * self, KSym kSym,
     return EVENT_RESPONSE_ABSORB;
 }
 
+EventResponse self_handle_page_up(IBusChewingPreEdit * self, KSym kSym,
+                                  KeyModifiers unmaskedMod)
+{
+    filter_modifiers(0);
+    ignore_when_buffer_is_empty_and_table_not_showing;
+    ignore_when_release;
+    handle_log("page_up");
+
+    int currentPage = chewing_cand_CurrentPage(self->context);
+
+    if (table_is_showing && (currentPage == 0)) {
+        return event_process_or_ignore(!chewing_handle_Down(self->context));
+    }
+    
+    return event_process_or_ignore(!chewing_handle_PageUp(self->context));
+}
+
+EventResponse self_handle_page_down(IBusChewingPreEdit * self, KSym kSym,
+                                    KeyModifiers unmaskedMod)
+{
+    filter_modifiers(0);
+    ignore_when_buffer_is_empty_and_table_not_showing;
+    ignore_when_release;
+    handle_log("page_down");
+
+    int totalPage = chewing_cand_TotalPage(self->context);
+    int currentPage = chewing_cand_CurrentPage(self->context);
+
+    if (table_is_showing && (currentPage == totalPage - 1)) {
+        return event_process_or_ignore(!chewing_handle_Down(self->context));
+    }
+
+    return event_process_or_ignore(!chewing_handle_PageDown(self->context));
+}
+
 EventResponse self_handle_space(IBusChewingPreEdit * self, KSym kSym,
                                 KeyModifiers unmaskedMod)
 {
     filter_modifiers(IBUS_SHIFT_MASK | IBUS_CONTROL_MASK);
+
     if (!is_shift_only && !is_chinese && !is_full_shape) { 
 	/* Let libchewing handles Keypad keys only when needed.
 	 * Otherwise it might cause some issues. Github 144.
 	 */
         ignore_when_buffer_is_empty_and_table_not_showing; 
     }
+
     ignore_when_release;
     handle_log("space");
 
     if (is_shift_only) {
         ibus_chewing_pre_edit_toggle_full_half_mode(self);
         return EVENT_RESPONSE_PROCESS;
+    }
+
+    /* Bug of libchewing: 
+     * If "Space as selection" is not enabled, Space key cannot be used
+     * to turn pages or switch the length of candidate lis.
+     */
+    if (table_is_showing) {
+        return self_handle_page_down(self, kSym, unmaskedMod);
     }
 
     /* Bug of libchewing: 
@@ -580,6 +625,8 @@ EventResponse self_handle_left(IBusChewingPreEdit * self, KSym kSym,
                 return EVENT_RESPONSE_ABSORB;
             }
         }
+
+        return self_handle_page_up(self, kSym, unmaskedMod);
     }
 
     return event_process_or_ignore(!chewing_handle_Left(self->context));
@@ -602,7 +649,8 @@ EventResponse self_handle_up(IBusChewingPreEdit * self, KSym kSym,
                 return EVENT_RESPONSE_ABSORB;
             }
         }
-            return event_process_or_ignore(!chewing_handle_Left(self->context));
+
+        return self_handle_page_up(self, kSym, unmaskedMod);
     }
 
     return event_process_or_ignore(!chewing_handle_Up(self->context));
@@ -622,6 +670,7 @@ EventResponse self_handle_right(IBusChewingPreEdit * self, KSym kSym,
     }
 
     if (table_is_showing) {
+
         if(!ibus_chewing_pre_edit_is_vertical_table(self)) {
             /* horizontal look-up table */
             int numberCand = ibus_lookup_table_get_number_of_candidates(self->iTable);
@@ -631,7 +680,8 @@ EventResponse self_handle_right(IBusChewingPreEdit * self, KSym kSym,
                 return EVENT_RESPONSE_ABSORB;
             }
         }
-        return event_process_or_ignore(!chewing_handle_Space(self->context));
+
+        return self_handle_page_down(self, kSym, unmaskedMod);
     }
 
     return event_process_or_ignore(!chewing_handle_Right(self->context));
@@ -656,44 +706,12 @@ EventResponse self_handle_down(IBusChewingPreEdit * self, KSym kSym,
                 return EVENT_RESPONSE_ABSORB;
             }
         }
-        return event_process_or_ignore(!chewing_handle_Space(self->context));
+
+        /* horizontal look-up table */
+        return self_handle_page_down(self, kSym, unmaskedMod);
     }
 
     return event_process_or_ignore(!chewing_handle_Down(self->context));
-}
-
-EventResponse self_handle_page_up(IBusChewingPreEdit * self, KSym kSym,
-                                  KeyModifiers unmaskedMod)
-{
-    filter_modifiers(0);
-    ignore_when_buffer_is_empty_and_table_not_showing;
-    ignore_when_release;
-    handle_log("page_up");
-
-#if !CHEWING_CHECK_VERSION(0,4,0)
-    if (table_is_showing) {
-        return event_process_or_ignore(!chewing_handle_Left(self->context));
-    }
-#endif
-
-    return event_process_or_ignore(!chewing_handle_PageUp(self->context));
-}
-
-EventResponse self_handle_page_down(IBusChewingPreEdit * self, KSym kSym,
-                                    KeyModifiers unmaskedMod)
-{
-    filter_modifiers(0);
-    ignore_when_buffer_is_empty_and_table_not_showing;
-    ignore_when_release;
-    handle_log("page_down");
-
-#if !CHEWING_CHECK_VERSION(0,4,0)
-    if (table_is_showing) {
-        return event_process_or_ignore(!chewing_handle_Right(self->context));
-    }
-#endif
-
-    return event_process_or_ignore(!chewing_handle_PageDown(self->context));
 }
 
 EventResponse self_handle_tab(IBusChewingPreEdit * self, KSym kSym,

--- a/src/IBusChewingPreEdit.h
+++ b/src/IBusChewingPreEdit.h
@@ -110,7 +110,7 @@ void ibus_chewing_pre_edit_free(IBusChewingPreEdit * self);
 
 #    define ibus_chewing_pre_edit_is_system_keyboard_layout(self) ibus_chewing_properties_read_boolean_general(self->iProperties, "ibus/general", "use-system-keyboard-layout", NULL)
 
-#    define ibus_chewing_pre_edit_is_vertical_table(self) ibus_chewing_properties_read_int_general(self->iProperties, "ibus/panel", "lookup-table-orientation", NULL)
+#    define ibus_chewing_pre_edit_is_vertical_table(self) mkdg_properties_get_boolean_by_key(self->iProperties->properties, "vertical-lookup-table")
 
 #    define ibus_chewing_pre_edit_apply_property(self,propertyKey) mkdg_properties_apply_by_key(self->iProperties->properties, propertyKey, NULL)
 

--- a/src/IBusChewingProperties.c
+++ b/src/IBusChewingProperties.c
@@ -216,6 +216,15 @@ MkdgPropertySpec propSpecs[] = {
      NULL}
     ,
     {
+     G_TYPE_BOOLEAN, "vertical-lookup-table", PAGE_SELECTING,
+     N_("Vertical Lookup Table"),
+     IBUS_CHEWING_PROPERTIES_SUBSECTION,
+     "0", NULL, NULL, 0, 1,
+     verticalLookupTable_apply_callback, 0,
+     "Use vertical lookup table.",
+     NULL}
+    ,
+    {
      G_TYPE_INVALID, "", "", "",
      IBUS_CHEWING_PROPERTIES_SUBSECTION, "", NULL, NULL, 0, 0,
      NULL, 0, NULL, NULL}

--- a/src/IBusChewingProperties.h
+++ b/src/IBusChewingProperties.h
@@ -88,6 +88,8 @@ gboolean defaultEnglishLetterCase_apply_callback(PropertyContext * ctx,
 
 gboolean plainZhuyin_apply_callback(PropertyContext * ctx, gpointer userData);
 
+gboolean verticalLookupTable_apply_callback(PropertyContext * ctx, gpointer userData);
+
 extern MkdgPropertySpec propSpecs[];
 
 extern const gchar *kbType_ids[];


### PR DESCRIPTION
* Fix undesired behavior from libchewing, let space key turns pages
and switch length of the candidate list.

 * Make all turn-page-keys like arrow keys, space key, page down... etc.
able to switch length of the candidate list.

 * Add option: vertical lookup table. The settings from ibus-setup will be 
ignored in some Desktop Environment, so we need to add this option in 
the ibus-chewing setup.
