### PR TITLE
Support vertical lookup table and optimize turn page keys

### DIFF
--- a/src/IBusChewingApplier.c
+++ b/src/IBusChewingApplier.c
@@ -195,3 +195,9 @@ gboolean plainZhuyin_apply_callback(PropertyContext * ctx, gpointer userData)
     /* Use MkdgProperty directly, no need to call IBusChewingEngine */
     return TRUE;
 }
+
+gboolean verticalLookupTable_apply_callback(PropertyContext * ctx, gpointer userData)
+{
+    /* Use MkdgProperty directly, no need to call IBusChewingEngine */
+    return TRUE;
+}

--- a/src/IBusChewingLookupTable.c
+++ b/src/IBusChewingLookupTable.c
@@ -1,5 +1,6 @@
 #include "IBusChewingUtil.h"
 #include "IBusChewingLookupTable.h"
+#include "MakerDialogProperty.h"
 
 IBusLookupTable *ibus_chewing_lookup_table_new(IBusChewingProperties *
                                                iProperties,
@@ -12,6 +13,7 @@ IBusLookupTable *ibus_chewing_lookup_table_new(IBusChewingProperties *
         (size, 0, cursorShow, wrapAround);
 
     ibus_chewing_lookup_table_resize(iTable, iProperties, context);
+
     return iTable;
 }
 
@@ -46,6 +48,12 @@ void ibus_chewing_lookup_table_resize(IBusLookupTable * iTable,
     }
     chewing_set_candPerPage(context, len);
     chewing_set_selKey(context, selKSym, len);
+
+    gboolean verticalLookupTable =
+        mkdg_properties_get_boolean_by_key(iProperties->properties,
+                                                   "vertical-lookup-table");
+
+    ibus_lookup_table_set_orientation(iTable, verticalLookupTable);
 }
 
 guint ibus_chewing_lookup_table_update(IBusLookupTable * iTable,

--- a/src/IBusChewingPreEdit.h
+++ b/src/IBusChewingPreEdit.h
@@ -110,7 +110,7 @@ void ibus_chewing_pre_edit_free(IBusChewingPreEdit * self);
 
 #    define ibus_chewing_pre_edit_is_system_keyboard_layout(self) ibus_chewing_properties_read_boolean_general(self->iProperties, "ibus/general", "use-system-keyboard-layout", NULL)
 
-#    define ibus_chewing_pre_edit_is_vertical_table(self) ibus_chewing_properties_read_int_general(self->iProperties, "ibus/panel", "lookup-table-orientation", NULL)
+#    define ibus_chewing_pre_edit_is_vertical_table(self) mkdg_properties_get_boolean_by_key(self->iProperties->properties, "vertical-lookup-table")
 
 #    define ibus_chewing_pre_edit_apply_property(self,propertyKey) mkdg_properties_apply_by_key(self->iProperties->properties, propertyKey, NULL)
 

--- a/src/IBusChewingProperties.c
+++ b/src/IBusChewingProperties.c
@@ -216,6 +216,15 @@ MkdgPropertySpec propSpecs[] = {
      NULL}
     ,
     {
+     G_TYPE_BOOLEAN, "vertical-lookup-table", PAGE_SELECTING,
+     N_("Vertical Lookup Table"),
+     IBUS_CHEWING_PROPERTIES_SUBSECTION,
+     "0", NULL, NULL, 0, 1,
+     verticalLookupTable_apply_callback, 0,
+     "Use vertical lookup table.",
+     NULL}
+    ,
+    {
      G_TYPE_INVALID, "", "", "",
      IBUS_CHEWING_PROPERTIES_SUBSECTION, "", NULL, NULL, 0, 0,
      NULL, 0, NULL, NULL}

--- a/src/IBusChewingProperties.h
+++ b/src/IBusChewingProperties.h
@@ -88,6 +88,8 @@ gboolean defaultEnglishLetterCase_apply_callback(PropertyContext * ctx,
 
 gboolean plainZhuyin_apply_callback(PropertyContext * ctx, gpointer userData);
 
+gboolean verticalLookupTable_apply_callback(PropertyContext * ctx, gpointer userData);
+
 extern MkdgPropertySpec propSpecs[];
 
 extern const gchar *kbType_ids[];

--- a/test/IBusChewingPreEdit-test.c
+++ b/test/IBusChewingPreEdit-test.c
@@ -739,6 +739,9 @@ void test_arrow_keys_buffer_empty()
 /* GitHub #50: Cannot use Up, Down, PgUp, Ese ... etc. within "`" menu */
 
     TEST_CASE_INIT();
+    ibus_chewing_pre_edit_set_apply_property_boolean(self,
+                                                     "vertical-lookup-table",
+                                                     TRUE);
 
     key_press_from_string("`");
     g_assert(ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
@@ -751,17 +754,12 @@ void test_arrow_keys_buffer_empty()
     g_assert(chewing_cand_CurrentPage(self->context) == 1);
     key_press_from_key_sym(IBUS_KEY_Page_Up, 0);
     g_assert(chewing_cand_CurrentPage(self->context) == 0);
-    key_press_from_key_sym(IBUS_KEY_Up, 0);
+    key_press_from_key_sym(IBUS_KEY_Escape, 0);
     g_assert(!ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
 
     key_press_from_string("`");
     g_assert(ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
     key_press_from_key_sym(IBUS_KEY_BackSpace, 0);
-    g_assert(!ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
-
-    key_press_from_string("`");
-    g_assert(ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
-    key_press_from_key_sym(IBUS_KEY_Escape, 0);
     g_assert(!ibus_chewing_pre_edit_has_flag(self, FLAG_TABLE_SHOW));
 }
 


### PR DESCRIPTION
 * The settings from ibus-setup will be ignored in some Desktop Environment, so we need to add this option into the ibus-chewing setup.

 * Fix undesired behavior from libchewing, let space key turns pages and switch length of the candidate list (#154).

 * Make all turn-page-keys like arrow keys, space key, page down... etc. able to switch length of the candidate list.

 * Update test case