### PR TITLE
Add dropdown menu for Chi-Eng-Mode toggle key

### DIFF
--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -9,201 +9,247 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ibus-chewing 1.5.0\n"
 "Report-Msgid-Bugs-To: Ding-Yi Chen <dchen at redhat.com>\n"
-"POT-Creation-Date: 2016-05-02 00:48+1000\n"
+"POT-Creation-Date: 2023-12-02 22:36+0800\n"
+"PO-Revision-Date: 2023-12-02 23:18+0800\n"
+"Last-Translator: Ding-Yi Chen <dchen@redhat.com>\n"
+"Language-Team: Chinese (Traditional Han, Taiwan)\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2016-05-01 10:52-0400\n"
-"Last-Translator: Ding-Yi Chen <dchen@redhat.com>\n"
-"Language-Team: Chinese (Traditional Han, Taiwan)\n"
-"Language: zh-TW\n"
-"X-Generator: Zanata 3.9.6\n"
-"Plural-Forms: nplurals=1; plural=0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.4\n"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:13
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:13
 msgid "Editing"
 msgstr "編輯"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:14
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:14
 msgid "Selecting"
 msgstr "選字"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:15
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:15
 msgid "Keyboard"
 msgstr "鍵盤"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:18
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:18
 msgid "default"
 msgstr "預設"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:19
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:19
 msgid "hsu"
 msgstr "許氏"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:20
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:20
 msgid "ibm"
 msgstr "IBM"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:21
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:21
 msgid "gin_yieh"
 msgstr "精業"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:22
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:22
 msgid "eten"
 msgstr "倚天"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:23
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:23
 msgid "eten26"
 msgstr "倚天26鍵"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:24
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:24
 msgid "dvorak"
 msgstr "Dvorak"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:25
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:25
 msgid "dvorak_hsu"
 msgstr "Dvorak+許氏"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:26
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:26
 msgid "dachen_26"
 msgstr "大千26鍵"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:27
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:27
 msgid "hanyu"
 msgstr "漢語"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:45
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:29
+msgid "thl_pinying"
+msgstr "台灣華語羅馬拼音"
+
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:30
+msgid "mps2_pinyin"
+msgstr "MPS2 拼音"
+
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:49
 msgid "no default"
 msgstr "無預設值"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:46
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:50
 msgid "lowercase"
 msgstr "小寫"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:47
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:51
 msgid "uppercase"
 msgstr "大寫"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:52
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:56
 msgctxt "Sync"
 msgid "disable"
 msgstr "停用"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:53
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:57
 msgctxt "Sync"
 msgid "keyboard"
 msgstr "由鍵盤"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:54
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:58
 msgctxt "Sync"
 msgid "input method"
 msgstr "由輸入法"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:59
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:63
 msgid "Auto"
 msgstr "自動"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:60
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:64
 msgid "Big5"
 msgstr "Big5"
 
 # translation auto-copied from project ibus-chewing, version 1.3.10, document ibus-chewing, author dchen
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:61
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:65
 msgid "UTF8"
 msgstr "UTF8"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:66
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:70
+msgid "caps_lock"
+msgstr "Caps Lock"
+
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:71
+msgid "shift"
+msgstr "Shift"
+
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:72
+msgid "shift_l"
+msgstr "Shift L"
+
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:73
+msgid "shift_r"
+msgstr "Shift R"
+
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:78
 msgid "Keyboard Type"
 msgstr "鍵盤排列"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:70
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:82
 msgid "Select Zhuyin keyboard layout"
 msgstr "選擇注音符號的鍵盤排列"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:72
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:84
 msgid "Selection keys"
 msgstr "選字按鍵"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:78
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:91
 msgid ""
 "Keys used to select candidate. For example \"asdfghjkl;\", press 'a' to "
 "select the 1st candidate, 's' for 2nd, and so on."
-msgstr "設定選字按鍵。以 \"asdfghjkl;\" 為例，按 'a' 選第一個候選字詞，按 's' 選第二個，依此類推。"
+msgstr ""
+"設定選字按鍵。以 \"asdfghjkl;\" 為例，按 'a' 選第一個候選字詞，按 's' 選第二"
+"個，依此類推。"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:82
-msgid "Hsu's selection key"
-msgstr "許式鍵盤選擇鍵"
-
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:86
-msgid "Hsu's keyboard selection keys, 1 for asdfjkl789, 2 for asdfzxcv89 ."
-msgstr "許氏鍵盤選擇鍵設定。1 為使用 asdfjkl789，2 為使用asdfzxcv89。"
-
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:91
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:96
 msgid "Show systray icons"
 msgstr "在系統匣顯示圖示"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:95
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:100
 msgid ""
 "On: Show Chinese/English and Full/Half shape status as a systray icon\n"
 "Off: Do not show the status icon"
-msgstr "開：在系統匣顯示中/英文與全/半形狀態\n"
+msgstr ""
+"開：在系統匣顯示中/英文與全/半形狀態\n"
 "關：不在系統匣顯示任何圖示"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:99
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:104
 msgid "Auto move cursor"
 msgstr "自動移動游標"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:102
-msgid "Automatically move cursor to next character"
-msgstr "自動移游標至下一個字"
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:107
+msgid "Automatically move the cursor to the next character after selection"
+msgstr "選字後，自動將游標移到下一個字"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:105
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:108
-msgid "Add phrases to the front"
-msgstr "前方加詞"
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:110
+msgid "Add phrase before the cursor"
+msgstr "新增游標前方的詞"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:111
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:113
+msgid "Use Ctrl + Numbers (2-9) to add new phrase before the cursor"
+msgstr "使用 Ctrl 鍵 + 數字鍵 (2-9) 來新增游標前方的詞"
+
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:116
 msgid "Clean pre-edit buffer when focus out"
 msgstr "當輸入焦點移開後清空預編區"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:115
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:120
 msgid ""
 "On: Clean pre-edit buffer when focus out to prevent program crash\n"
 "Off: Keep what you already type for convenience"
-msgstr "開：當輸入焦點移開後清空預編區，以預防程式崩潰\n"
+msgstr ""
+"開：當輸入焦點移開後清空預編區，以預防程式崩潰\n"
 "關：不清空預編區，回來可以接者輸入"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:119
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:124
 msgid "Easy symbol input"
 msgstr "簡易符號輸入"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:122
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:127
 msgid "Press shift to input Chinese punctuation symbols"
 msgstr "按下 shift 來輸入中文標點符號"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:125
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:130
 msgid "Esc clean all buffer"
 msgstr "Esc 鍵清預編區"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:128
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:133
 msgid "Escape key cleans the text in pre-edit-buffer"
 msgstr "Esc 鍵清預編區內文字"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:131
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:136
 msgid "Maximum Chinese characters"
 msgstr "容納中文字數"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:135
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:140
 msgid ""
-"Maximum Chinese characters in pre-edit buffer, including inputing Zhuyin "
+"Maximum Chinese characters in pre-edit buffer, not including inputing Zhuyin "
 "symbols."
-msgstr "預編區最大可容納中文字數，包含注音符號。"
+msgstr "預編區可容納的中文字數上限，包含注音符號。"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:140
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:147
+msgid "Chinese/Alphanumeric Mode Toggle Key"
+msgstr "中英模式切換鍵"
+
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:162
+msgid ""
+"Default English letter case\n"
+"(Only effective when Caps Lock is the toggle key)"
+msgstr ""
+"預設英文大小寫\n"
+"(只限於使用 Caps Lock 切換中英模式時)"
+
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:169
+msgid ""
+"no control: No default letter case. Not recommend if you use multiple "
+"keyboards or synergy\n"
+"lowercase: Default to lowercase, press shift for uppercase.\n"
+"uppercase: Default to uppercase, press shift for lowercase."
+msgstr ""
+"不控制： 不特別設定大小寫。若使用多個鍵盤或是 synergy 時，不建議使用\n"
+"小寫： 預設為小寫。用 shift 來輸入大寫\n"
+"大寫： 預設為大寫。用 shift 來輸入小寫"
+
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:176
 msgid "Sync between CapsLock and IM"
-msgstr "CapsLock與輸入法狀態同步"
+msgstr "Caps Lock 與輸入法狀態同步"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:147
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:183
 msgid ""
 "Occasionally, the CapsLock status does not match the IM, this option "
 "determines how these status be synchronized. Valid values:\n"
@@ -216,133 +262,130 @@ msgstr ""
 "「由鍵盤」：輸入法向鍵盤同步\n"
 "「由輸入法」：鍵盤向輸入法同步"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:153
-msgid "Number pad always input number"
-msgstr "數字版總是輸入數字"
-
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:156
-msgid "Always input numbers when number keys from key pad is inputted"
-msgstr "用數字版輸入時總是輸入數字，並不負責選字"
-
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:160
-msgid "Shift toggle Chinese Mode"
-msgstr "Shift 切換中文"
-
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:163
-msgid "Shift key to toggle Chinese Mode"
-msgstr "Shift 鍵切換中文模式"
-
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:166
-msgid "Caps Lock toggles Chinese Mode"
-msgstr "Caps Lock 切換中文模式"
-
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:169
-msgid ""
-"On: Caps Lock toggle Chinese/English\n"
-"Off: Caps Lock only affect English letter case"
-msgstr "開： Caps Lock 切換中/英\n"
-"關： Caps Lock 只切換英文大小寫"
-
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:174
-msgid ""
-"Default English letter case\n"
-"  (Only effective when Caps Lock toggles Chinese is ON)"
-msgstr "預設英文大小寫\n"
-"(只在「Caps Lock 切換中/英」啟用時作用)"
-
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:180
-msgid ""
-"no control: No default letter case. Not recommend if you use multiple "
-"keyboards or synergy\n"
-"lowercase: Default to lowercase, press shift for uppercase.\n"
-"uppercase: Default to uppercase, press shift for lowercase."
-msgstr ""
-"不控制： 不特別設定大小寫。若使用多個鍵盤或是 synergy 時，不建議使用\n"
-"小寫： 預設為小寫。用 shift 來輸入大寫\n"
-"大寫： 預設為大寫。用 shift 來輸入小寫"
-
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:187
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:190
 msgid "Plain Zhuyin mode"
 msgstr "單純注音模式"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:191
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:194
 msgid ""
 "In plain Zhuyin mode, automatic candidate selection and related options are "
 "disabled or ignored."
 msgstr "在單純注音模式，自動選詞功能及選項將被關閉或忽略。"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:196
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:199
 msgid "Candidate per page"
 msgstr "每頁候選字數"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:199
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:202
 msgid "Number of candidate per page."
 msgstr "每頁可顯示候選字詞數。"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:204
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:207
+msgid "Show page number"
+msgstr "顯示頁碼"
+
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:210
+msgid "Display the page number of the candidate list."
+msgstr "顯示候選清單的頁碼"
+
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:215
 msgid "Choose phrases from backward"
 msgstr "後方選詞"
 
 # translation auto-copied from project ibus-chewing, version 1.3.10, document ibus-chewing, author dchen
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:207
-msgid "Choose phrases from the back, without moving cursor."
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:218
+msgid ""
+"Open candidate list from the back of a phrase, without moving the cursor to "
+"the front."
 msgstr "直接由後方選詞，不必把游標移到候選詞前。"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingProperties.c:212
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:223
 msgid "Space to select"
 msgstr "空白鍵選字"
 
-#: /home/dchen/ibus-chewing/po/../src/IBusChewingSystray.c:167
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingProperties.c:232
+msgid "Vertical Lookup Table"
+msgstr "垂直候選清單"
+
+#: /home/gecko123/github/ibus-chewing/po/../src/IBusChewingSystray.c:168
 msgid "Left click to toggle Chi/Eng; Right click to toggle full/half shape"
 msgstr "滑鼠左鍵切換中/英文；右鍵切換全/半形"
 
-#: /home/dchen/ibus-chewing/po/../src/MakerDialogWidget.c:7
+#: /home/gecko123/github/ibus-chewing/po/../src/MakerDialogWidget.c:7
 msgctxt "Configure"
 msgid "Cancel"
 msgstr "取消"
 
-#: /home/dchen/ibus-chewing/po/../src/MakerDialogWidget.c:8
+#: /home/gecko123/github/ibus-chewing/po/../src/MakerDialogWidget.c:8
 msgctxt "Configure"
 msgid "Save"
 msgstr "儲存"
 
-#: /home/dchen/ibus-chewing/po/../src/MakerDialogWidget.c:9
+#: /home/gecko123/github/ibus-chewing/po/../src/MakerDialogWidget.c:9
 msgctxt "Configure"
 msgid "Apply"
 msgstr "套用"
 
-#: /home/dchen/ibus-chewing/po/../src/MakerDialogWidget.c:10
+#: /home/gecko123/github/ibus-chewing/po/../src/MakerDialogWidget.c:10
 msgctxt "Configure"
 msgid "Close"
 msgstr "關閉"
 
-#: /home/dchen/ibus-chewing/po/../src/MakerDialogWidget.c:11
+#: /home/gecko123/github/ibus-chewing/po/../src/MakerDialogWidget.c:11
 msgctxt "Configure"
 msgid "Ok"
 msgstr "確定"
 
-#: /home/dchen/ibus-chewing/po/../src/ibus-setup-chewing.c:73
+#: /home/gecko123/github/ibus-chewing/po/../src/ibus-setup-chewing.c:74
 msgid "Setting"
 msgstr "設定"
 
-#: /home/dchen/ibus-chewing/po/../src/main.c:72
+#: /home/gecko123/github/ibus-chewing/po/../src/main.c:72
 msgid "Cannot connect to IBus!"
 msgstr "不能連到 IBus!"
 
-#: /home/dchen/ibus-chewing/po/../src/main.c:82
+#: /home/gecko123/github/ibus-chewing/po/../src/main.c:83
 msgid "Chewing component"
 msgstr "酷音元件"
 
-#: /home/dchen/ibus-chewing/po/../src/main.c:84
-#: /home/dchen/ibus-chewing/po/../src/main.c:99
+#: /home/gecko123/github/ibus-chewing/po/../src/main.c:85
+#: /home/gecko123/github/ibus-chewing/po/../src/main.c:99
 msgid "Peng Huang, Ding-Yi Chen"
 msgstr "黃鵬，陳定彞"
 
 # translation auto-copied from project ibus-chewing, version 1.3.10, document ibus-chewing, author dchen
-#: /home/dchen/ibus-chewing/po/../src/main.c:93
+#: /home/gecko123/github/ibus-chewing/po/../src/main.c:95
 msgid "Chewing"
 msgstr "新酷音"
 
-#: /home/dchen/ibus-chewing/po/../src/main.c:95
+#: /home/gecko123/github/ibus-chewing/po/../src/main.c:96
 msgid "Chinese chewing input method"
 msgstr "中文新酷音輸入法"
+
+#~ msgid "Hsu's selection key"
+#~ msgstr "許式鍵盤選擇鍵"
+
+#~ msgid "Hsu's keyboard selection keys, 1 for asdfjkl789, 2 for asdfzxcv89 ."
+#~ msgstr "許氏鍵盤選擇鍵設定。1 為使用 asdfjkl789，2 為使用asdfzxcv89。"
+
+#~ msgid "Number pad always input number"
+#~ msgstr "數字版總是輸入數字"
+
+#~ msgid "Always input numbers when number keys from key pad is inputted"
+#~ msgstr "用數字版輸入時總是輸入數字，並不負責選字"
+
+#~ msgid "Shift toggle Chinese Mode"
+#~ msgstr "Shift 切換中文"
+
+#~ msgid "Shift key to toggle Chinese Mode"
+#~ msgstr "Shift 鍵切換中文模式"
+
+#~ msgid "Caps Lock toggles Chinese Mode"
+#~ msgstr "Caps Lock 切換中文模式"
+
+#~ msgid ""
+#~ "On: Caps Lock toggle Chinese/English\n"
+#~ "Off: Caps Lock only affect English letter case"
+#~ msgstr ""
+#~ "開： Caps Lock 切換中/英\n"
+#~ "關： Caps Lock 只切換英文大小寫"

--- a/src/IBusChewingApplier.c
+++ b/src/IBusChewingApplier.c
@@ -134,17 +134,6 @@ gboolean syncCapsLock_apply_callback(PropertyContext * ctx, gpointer userData)
     return TRUE;
 }
 
-gboolean
-shiftToggleChinese_apply_callback(PropertyContext * ctx, gpointer userData)
-{
-    GValue *value = &(ctx->value);
-    IBusChewingPreEdit *icPreEdit = (IBusChewingPreEdit *) ctx->parent;
-
-    ibus_chewing_pre_edit_set_property_boolean
-        (icPreEdit, "shift-toggle-chinese", g_value_get_boolean(value));
-    return TRUE;
-}
-
 gboolean candPerPage_apply_callback(PropertyContext * ctx, gpointer userData)
 {
     IBusChewingPreEdit *icPreEdit = (IBusChewingPreEdit *) ctx->parent;
@@ -152,13 +141,6 @@ gboolean candPerPage_apply_callback(PropertyContext * ctx, gpointer userData)
     ibus_chewing_lookup_table_resize(icPreEdit->iTable,
                                      icPreEdit->iProperties,
                                      icPreEdit->context);
-    return TRUE;
-}
-
-gboolean
-    capslockToggleChinese_apply_callback
-    (PropertyContext * ctx, gpointer userData) {
-    /* Use MkdgProperty directly, no need to call IBusChewingEngine */
     return TRUE;
 }
 
@@ -197,6 +179,12 @@ gboolean plainZhuyin_apply_callback(PropertyContext * ctx, gpointer userData)
 }
 
 gboolean verticalLookupTable_apply_callback(PropertyContext * ctx, gpointer userData)
+{
+    /* Use MkdgProperty directly, no need to call IBusChewingEngine */
+    return TRUE;
+}
+
+gboolean chiEngToggle_apply_callback(PropertyContext * ctx, gpointer userData)
 {
     /* Use MkdgProperty directly, no need to call IBusChewingEngine */
     return TRUE;

--- a/src/IBusChewingPreEdit-private.h
+++ b/src/IBusChewingPreEdit-private.h
@@ -27,11 +27,13 @@
 #    define _IBUS_CHEWING_PRE_EDIT_PRIVATE_H_
 
 /*== Frequent used shortcut ==*/
-#    define cursor_current chewing_cursor_Current(self->context)
-#    define total_choice chewing_cand_TotalChoice(self->context)
-#    define default_english_case_short \
-        (STRING_EQUALS(ibus_chewing_pre_edit_get_property_string(self, "default-english-case"), "lowercase")) ? 'l' : \
-        (STRING_EQUALS(ibus_chewing_pre_edit_get_property_string(self, "default-english-case"), "uppercase") ? 'u' : 'n')
+#    define cursor_current              chewing_cursor_Current(self->context)
+#    define total_choice                chewing_cand_TotalChoice(self->context)
+#    define default_english_case_short  (STRING_EQUALS(ibus_chewing_pre_edit_get_property_string(self, "default-english-case"), "lowercase")) ? 'l' : \
+                                        (STRING_EQUALS(ibus_chewing_pre_edit_get_property_string(self, "default-english-case"), "uppercase") ? 'u' : 'n')
+#    define chi_eng_toggle_key          (STRING_EQUALS(ibus_chewing_pre_edit_get_property_string(self, "chi-eng-mode-toggle"), "caps_lock")) ? 'c' : \
+                                        (STRING_EQUALS(ibus_chewing_pre_edit_get_property_string(self, "chi-eng-mode-toggle"), "shift")) ? 's' : \
+                                        (STRING_EQUALS(ibus_chewing_pre_edit_get_property_string(self, "chi-eng-mode-toggle"), "shift_l") ? 'l' : 'n')
 
 /*== Conditional Expression Shortcut ==*/
 #    define is_plain_zhuyin ibus_chewing_pre_edit_get_property_boolean(self, "plain-zhuyin")

--- a/src/IBusChewingProperties.c
+++ b/src/IBusChewingProperties.c
@@ -66,6 +66,14 @@ const gchar *outputCharsets[] = {
     NULL
 };
 
+const gchar *chiEngToggle[] = {
+    N_("caps_lock"),
+    N_("shift"),
+    N_("shift_l"),
+    N_("shift_r"),
+    NULL
+};
+
 MkdgPropertySpec propSpecs[] = {
     {G_TYPE_STRING, "kb-type", PAGE_KEYBOARD, N_("Keyboard Type"),
      IBUS_CHEWING_PROPERTIES_SUBSECTION, "default", kbType_ids, NULL, 0, 0,
@@ -96,13 +104,13 @@ MkdgPropertySpec propSpecs[] = {
      N_("Auto move cursor"),
      IBUS_CHEWING_PROPERTIES_SUBSECTION, "1", NULL, NULL, 0, 1,
      autoShiftCur_apply_callback, 0,
-     N_("Automatically move cursor to next character"), NULL}
+     N_("Automatically move the cursor to the next character after selection"), NULL}
     ,
     {G_TYPE_BOOLEAN, "add-phrase-direction", PAGE_EDITING,
-     N_("Add phrases to the front"),
+     N_("Add phrase before the cursor"),
      IBUS_CHEWING_PROPERTIES_SUBSECTION, "1", NULL, NULL, 0, 1,
      addPhraseDirection_apply_callback, 0,
-     N_("Add phrases to the front"), NULL}
+     N_("Use Ctrl + Numbers (2-9) to add new phrase before the cursor"), NULL}
     ,
     {G_TYPE_BOOLEAN, "clean-buffer-focus-out", PAGE_EDITING,
      N_("Clean pre-edit buffer when focus out"),
@@ -132,37 +140,27 @@ MkdgPropertySpec propSpecs[] = {
      ("Maximum Chinese characters in pre-edit buffer, not including inputing Zhuyin symbols."),
      NULL}
     ,
-    /* Sync between CapsLock and IM */
-    {G_TYPE_STRING, "sync-caps-lock", PAGE_EDITING,
-     N_("Sync between CapsLock and IM"),
-     IBUS_CHEWING_PROPERTIES_SUBSECTION, "disable", syncCapsLock_strs,
-     "Sync",
-     0, 1,
-     syncCapsLock_apply_callback,
+    {
+     G_TYPE_STRING, 
+     "chi-eng-mode-toggle", 
+     PAGE_EDITING,
+     N_("Chinese/Alphanumeric Mode Toggle Key"),
+     IBUS_CHEWING_PROPERTIES_SUBSECTION, 
+     "caps_lock",
+     chiEngToggle, 
+     NULL, 
+     0, 
+     0,
+     chiEngToggle_apply_callback,
      MKDG_PROPERTY_FLAG_NO_NEW | MKDG_PROPERTY_FLAG_HAS_TRANSLATION,
-     N_
-     ("Occasionally, the CapsLock status does not match the IM, this option determines how these status be synchronized. Valid values:\n"
-      "\"disable\": Do nothing\n"
-      "\"keyboard\": IM status follows keyboard status\n"
-      "\"IM\": Keyboard status follows IM status"), NULL}
-    ,
-    {G_TYPE_BOOLEAN, "shift-toggle-chinese", PAGE_EDITING,
-     N_("Shift toggle Chinese Mode"),
-     IBUS_CHEWING_PROPERTIES_SUBSECTION, "1", NULL, NULL, 0, 1,
-     shiftToggleChinese_apply_callback, 0,
-     N_("Shift key to toggle Chinese Mode"), NULL}
-    ,
-    {G_TYPE_BOOLEAN, "capslock-toggle-chinese", PAGE_EDITING,
-     N_("Caps Lock toggles Chinese Mode"),
-     IBUS_CHEWING_PROPERTIES_SUBSECTION, "1", NULL, NULL, 0, 1,
-     capslockToggleChinese_apply_callback, 0,
-     N_("On: Caps Lock toggle Chinese/English\n"
-        "Off: Caps Lock only affect English letter case"), NULL}
+     NULL,
+     NULL
+     }
     ,
     {
      G_TYPE_STRING, "default-english-case", PAGE_EDITING,
      N_("Default English letter case\n"
-        "  (Only effective when Caps Lock toggles Chinese is ON)"),
+        "(Only effective when Caps Lock is the toggle key)"),
      IBUS_CHEWING_PROPERTIES_SUBSECTION, "lowercase",
      propDefaultEnglishLettercase_array, NULL, 0, 1,
      defaultEnglishLetterCase_apply_callback,
@@ -172,6 +170,20 @@ MkdgPropertySpec propSpecs[] = {
       "lowercase: Default to lowercase, press shift for uppercase.\n"
       "uppercase: Default to uppercase, press shift for lowercase."),
      NULL}
+    ,
+    /* Sync between CapsLock and IM */
+    {G_TYPE_STRING, "sync-caps-lock", PAGE_EDITING,
+     N_("Sync between CapsLock and IM"),
+     IBUS_CHEWING_PROPERTIES_SUBSECTION, "keyboard", syncCapsLock_strs,
+     "Sync",
+     0, 1,
+     syncCapsLock_apply_callback,
+     MKDG_PROPERTY_FLAG_NO_NEW | MKDG_PROPERTY_FLAG_HAS_TRANSLATION,
+     N_
+     ("Occasionally, the CapsLock status does not match the IM, this option determines how these status be synchronized. Valid values:\n"
+      "\"disable\": Do nothing\n"
+      "\"keyboard\": IM status follows keyboard status\n"
+      "\"IM\": Keyboard status follows IM status"), NULL}
     ,
     {
      G_TYPE_BOOLEAN, "plain-zhuyin", PAGE_SELECTING,
@@ -203,7 +215,7 @@ MkdgPropertySpec propSpecs[] = {
      N_("Choose phrases from backward"),
      IBUS_CHEWING_PROPERTIES_SUBSECTION, "1", NULL, NULL, 0, 1,
      phraseChoiceRearward_apply_callback, 0,
-     N_("Choose phrases from the back, without moving cursor."),
+     N_("Open candidate list from the back of a phrase, without moving the cursor to the front."),
      NULL}
     ,
     {

--- a/src/IBusChewingProperties.h
+++ b/src/IBusChewingProperties.h
@@ -66,13 +66,7 @@ gboolean forceLowercaseEnglish_apply_callback(PropertyContext * ctx,
 
 gboolean syncCapsLock_apply_callback(PropertyContext * ctx, gpointer userData);
 
-gboolean shiftToggleChinese_apply_callback(PropertyContext * ctx,
-                                           gpointer userData);
-
 gboolean candPerPage_apply_callback(PropertyContext * ctx, gpointer userData);
-
-gboolean capslockToggleChinese_apply_callback(PropertyContext * ctx,
-                                              gpointer userData);
 
 gboolean phraseChoiceRearward_apply_callback(PropertyContext * ctx,
                                              gpointer userData);
@@ -89,6 +83,8 @@ gboolean defaultEnglishLetterCase_apply_callback(PropertyContext * ctx,
 gboolean plainZhuyin_apply_callback(PropertyContext * ctx, gpointer userData);
 
 gboolean verticalLookupTable_apply_callback(PropertyContext * ctx, gpointer userData);
+
+gboolean chiEngToggle_apply_callback(PropertyContext * ctx, gpointer userData);
 
 extern MkdgPropertySpec propSpecs[];
 

--- a/test/IBusChewingPreEdit-test.c
+++ b/test/IBusChewingPreEdit-test.c
@@ -175,8 +175,9 @@ void self_key_sym_fix_test()
 {
     ibus_chewing_pre_edit_set_chi_eng_mode(self, FALSE);
 
-    ibus_chewing_pre_edit_set_property_boolean(self,
-                                               "capslock-toggle-chinese", TRUE);
+    ibus_chewing_pre_edit_set_property_string(self, "chi-eng-mode-toggle",
+                                              "caps_lock");
+
     ibus_chewing_pre_edit_set_property_string(self, "default-english-case",
                                               "no control");
     g_assert(self_key_sym_fix(self, '1', 0) == '1');
@@ -220,9 +221,9 @@ void self_key_sym_fix_test()
     g_assert(self_key_sym_fix(self, 'C', IBUS_SHIFT_MASK | IBUS_LOCK_MASK)
              == 'c');
 
-    ibus_chewing_pre_edit_set_property_boolean(self,
-                                               "capslock-toggle-chinese",
-                                               FALSE);
+    ibus_chewing_pre_edit_set_property_string(self, "chi-eng-mode-toggle",
+                                              "shift");
+
     ibus_chewing_pre_edit_set_property_string(self, "default-english-case",
                                               "no control");
     g_assert(self_key_sym_fix(self, 'd', 0) == 'd');
@@ -272,8 +273,10 @@ void self_key_sym_fix_test()
      * Chinese properly.
      */
     ibus_chewing_pre_edit_set_chi_eng_mode(self, TRUE);
-    ibus_chewing_pre_edit_set_property_boolean(self,
-                                               "capslock-toggle-chinese", TRUE);
+
+    ibus_chewing_pre_edit_set_property_string(self, "chi-eng-mode-toggle",
+                                              "caps_lock");
+
     ibus_chewing_pre_edit_set_property_string(self, "default-english-case",
                                               "no control");
     g_assert(self_key_sym_fix(self, 'e', 0) == 'e');
@@ -315,9 +318,9 @@ void self_key_sym_fix_test()
     g_assert(self_key_sym_fix(self, 'G', IBUS_SHIFT_MASK | IBUS_LOCK_MASK)
              == 'G');
 
-    ibus_chewing_pre_edit_set_property_boolean(self,
-                                               "capslock-toggle-chinese",
-                                               FALSE);
+    ibus_chewing_pre_edit_set_property_string(self, "chi-eng-mode-toggle",
+                                              "shift");
+
     ibus_chewing_pre_edit_set_property_string(self, "default-english-case",
                                               "no control");
     g_assert(self_key_sym_fix(self, 'h', 0) == 'h');
@@ -458,6 +461,10 @@ void process_key_text_with_symbol_test()
 void process_key_mix_test()
 {
     TEST_CASE_INIT();
+
+    ibus_chewing_pre_edit_set_property_string(self, "chi-eng-mode-toggle",
+                                              "shift");
+
     key_press_from_string("5k4g4");
     key_press_from_key_sym(IBUS_KEY_Shift_L, 0);
     key_press_from_string("ibus-chewing ");
@@ -523,8 +530,11 @@ void process_key_down_arrow_test()
 /* Test shift then caps then caps then shift */
 /* String: 我要去 Brisbane 了。Daddy 好嗎 */
 /* Bug before 1.5.0 */
+/* Should be okay to remove this since we force users to choose between caps and shift */
 void process_key_shift_and_caps_test()
 {
+#if 0
+
     TEST_CASE_INIT();
     ibus_chewing_pre_edit_set_apply_property_boolean(self,
                                                      "plain-zhuyin", FALSE);
@@ -572,6 +582,7 @@ void process_key_shift_and_caps_test()
 
     ibus_chewing_pre_edit_clear(self);
     assert_outgoing_pre_edit("", "");
+#endif
 }
 
 void full_half_shape_test()
@@ -626,9 +637,9 @@ void plain_zhuyin_shift_symbol_test()
     ibus_chewing_pre_edit_set_apply_property_boolean(self,
                                                      "plain-zhuyin", TRUE);
     g_assert(ibus_chewing_pre_edit_get_property_boolean(self, "plain-zhuyin"));
-    ibus_chewing_pre_edit_set_apply_property_boolean(self,
-                                                     "shift-toggle-chinese",
-                                                     TRUE);
+
+    ibus_chewing_pre_edit_set_property_string(self, "chi-eng-mode-toggle",
+                                              "shift");
 
     key_press_from_string("su31cl31");
 


### PR DESCRIPTION
 * Allowing Caps Lock and Shift as Chi-Eng-Mode toggle key at the same time often causes chaos during inputting and ruines user experience, so we use dropdown menu to simplify the use cases.

 * Separate Shift-L and Shift-R as some users need.

 * Update zh_TW translation